### PR TITLE
Added configuration option for aggregation attribute size

### DIFF
--- a/config/getcandy.php
+++ b/config/getcandy.php
@@ -135,6 +135,9 @@ return [
                     'large' => [500, 600, 700, 800],
                 ],
             ],
+            'attribute' => [
+                'size' => env('SEARCH_AGGREGATION_ATTRIBUTE_SIZE'),
+            ],
         ],
         /*
          * This is some experimental ranking, text searching has it's limits

--- a/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
+++ b/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
@@ -43,9 +43,12 @@ class Attribute
 
     public function getPre()
     {
+        $size = (int)config('getcandy.search.aggregation.attribute.size', 10);
+
         if (empty($this->filters)) {
             $agg = new Terms($this->field);
             $agg->setField($this->field.'.filter');
+            $agg->setSize($size);
 
             return $agg;
         }
@@ -54,6 +57,7 @@ class Attribute
 
         $agg = new Terms($this->field);
         $agg->setField($this->field.'.filter');
+        $agg->setSize($size);
 
         $postBool = new BoolQuery();
 
@@ -71,7 +75,7 @@ class Attribute
     {
         $agg = new Filter($this->field.'_after');
 
-        if (! is_array($value)) {
+        if (!is_array($value)) {
             $value = [$value];
         }
 

--- a/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
+++ b/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
@@ -43,7 +43,7 @@ class Attribute
 
     public function getPre()
     {
-        $size = (int)config('getcandy.search.aggregation.attribute.size', 10);
+        $size = (int) config('getcandy.search.aggregation.attribute.size', 10);
 
         if (empty($this->filters)) {
             $agg = new Terms($this->field);
@@ -75,7 +75,7 @@ class Attribute
     {
         $agg = new Filter($this->field.'_after');
 
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             $value = [$value];
         }
 


### PR DESCRIPTION
Currently the default aggregation size for attributes is `10`, set by Elastic. This PR allows a simple configuration option of:

```
SEARCH_AGGREGATION_ATTRIBUTE_SIZE=100
```

to be added to your `.env` file so this value can be changed.