### PR TITLE
Add config support for Elastic client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+#v0.2.5
+
+- [changed] The country name column in the database is now a text field, we aim to support translation files instead for this.
+- [added] You can now specify search config for the client.
+
+``` php
+    // Rest of getcandy.php config
+    'search' => [
+        'client_config' => [
+            'elastic' => [
+                'host' => null,
+                'port' => null,
+                'path' => null,
+                'url' => null,
+                'proxy' => null,
+                'transport' => null,
+                'persistent' => true,
+                'timeout' => null,
+                'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
+                'roundRobin' => false,
+                'log' => false,
+                'retryOnConflict' => 0,
+                'bigintConversion' => false,
+                'username' => null,
+                'password' => null,
+            ]
+        ],
+    ]
+```
+
+
 #v0.2.4
 
 - [fixed] Fixed issue with order searching caused by changing variant to description on order lines.

--- a/config/getcandy.php
+++ b/config/getcandy.php
@@ -121,6 +121,25 @@ return [
     */
     'search' => [
         'client' => \GetCandy\Api\Core\Search\Providers\Elastic\Elastic::class,
+        'client_config' => [
+            'elastic' => [
+                'host' => null,
+                'port' => null,
+                'path' => null,
+                'url' => null,
+                'proxy' => null,
+                'transport' => null,
+                'persistent' => true,
+                'timeout' => null,
+                'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
+                'roundRobin' => false,
+                'log' => false,
+                'retryOnConflict' => 0,
+                'bigintConversion' => false,
+                'username' => null,
+                'password' => null,
+            ]
+        ],
         'index_prefix' => env('SEARCH_INDEX_PREFIX', 'candy'),
         'index' => env('SEARCH_INDEX', 'candy_products_en'),
         /*

--- a/config/getcandy.php
+++ b/config/getcandy.php
@@ -138,7 +138,7 @@ return [
                 'bigintConversion' => false,
                 'username' => null,
                 'password' => null,
-            ]
+            ],
         ],
         'index_prefix' => env('SEARCH_INDEX_PREFIX', 'candy'),
         'index' => env('SEARCH_INDEX', 'candy_products_en'),

--- a/src/Core/Baskets/Factories/BasketFactory.php
+++ b/src/Core/Baskets/Factories/BasketFactory.php
@@ -6,8 +6,8 @@ use GetCandy\Api\Core\Orders\Models\Order;
 use GetCandy\Api\Core\Baskets\Models\Basket;
 use GetCandy\Api\Core\Baskets\Events\BasketFetchedEvent;
 use GetCandy\Api\Core\Baskets\Interfaces\BasketLineInterface;
-use GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface;
 use GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface;
+use GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface;
 
 class BasketFactory implements BasketFactoryInterface
 {
@@ -31,7 +31,6 @@ class BasketFactory implements BasketFactoryInterface
      * @var BasketLineInterface
      */
     public $lines;
-
 
     protected $tax;
 
@@ -86,12 +85,10 @@ class BasketFactory implements BasketFactoryInterface
             $discountTotal += $line->discount_total;
         }
 
-
         $this->basket->sub_total = $subTotal;
         $this->basket->discount_total = $discountTotal;
 
-
-        $this->basket->total_tax =  $this->tax->amount($subTotal - $discountTotal);
+        $this->basket->total_tax = $this->tax->amount($subTotal - $discountTotal);
         $this->basket->total_cost = ($this->basket->sub_total - $discountTotal) + $this->basket->total_tax;
 
         event(new BasketFetchedEvent($this->basket));

--- a/src/Core/Baskets/Factories/BasketLineFactory.php
+++ b/src/Core/Baskets/Factories/BasketLineFactory.php
@@ -115,7 +115,6 @@ class BasketLineFactory implements BasketLineInterface
                     }
                 }
             }
-
         }
 
         return $this->lines;

--- a/src/Core/Baskets/Services/BasketService.php
+++ b/src/Core/Baskets/Services/BasketService.php
@@ -8,11 +8,11 @@ use GetCandy\Api\Core\Discounts\Factory;
 use GetCandy\Api\Core\Orders\Models\Order;
 use GetCandy\Api\Core\Scaffold\BaseService;
 use GetCandy\Api\Core\Baskets\Models\Basket;
+use GetCandy\Api\Core\Discounts\Models\Discount;
 use GetCandy\Api\Core\Baskets\Models\SavedBasket;
 use GetCandy\Api\Core\Baskets\Events\BasketStoredEvent;
 use GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface;
 use GetCandy\Api\Core\Products\Interfaces\ProductVariantInterface;
-use GetCandy\Api\Core\Discounts\Models\Discount;
 
 class BasketService extends BaseService
 {
@@ -312,11 +312,9 @@ class BasketService extends BaseService
             'lines.variant.customerPricing',
         ])->findOrFail($id);
 
-
         $discount = app('api')->discounts()->getByHashedId($discountId);
 
         $basket->discounts()->detach($discount);
-
 
         event(new BasketStoredEvent($basket));
 

--- a/src/Core/Orders/Factories/OrderFactory.php
+++ b/src/Core/Orders/Factories/OrderFactory.php
@@ -12,10 +12,10 @@ use GetCandy\Api\Core\Shipping\Models\ShippingPrice;
 use GetCandy\Api\Core\Pricing\PriceCalculatorInterface;
 use GetCandy\Api\Core\Settings\Services\SettingService;
 use GetCandy\Api\Core\Orders\Interfaces\OrderFactoryInterface;
+use GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface;
+use GetCandy\Api\Core\Products\Interfaces\ProductVariantInterface;
 use GetCandy\Api\Core\Orders\Exceptions\BasketHasPlacedOrderException;
 use GetCandy\Api\Core\Currencies\Interfaces\CurrencyConverterInterface;
-use GetCandy\Api\Core\Products\Interfaces\ProductVariantInterface;
-use GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface;
 
 class OrderFactory implements OrderFactoryInterface
 {
@@ -318,7 +318,6 @@ class OrderFactory implements OrderFactoryInterface
         )->where('order_id', '=', $order->id)
         ->where('is_shipping', '=', false)->groupBy('order_id')->first();
 
-
         // If we don't have any totals, then we must have had an order already and deleted all the lines
         // from it and gone back to the checkout.
         if (! $totals) {
@@ -338,14 +337,12 @@ class OrderFactory implements OrderFactoryInterface
                 DB::RAW('line_total + tax_total - discount_total as grand_total')
             )->whereIsShipping(true)->first();
 
-
         if ($shipping) {
             $totals->delivery_total += $shipping->line_total;
             $totals->tax_total += $shipping->tax_total;
             $totals->discount_total += $shipping->discount_total;
             $totals->grand_total += $shipping->grand_total;
         }
-
 
         $order->update([
             'delivery_total' => $totals->delivery_total ?? 0,
@@ -486,7 +483,6 @@ class OrderFactory implements OrderFactoryInterface
                                     $product->product->variants->first()
                                 )->get();
 
-
                                 // Work out how many times we need to add this product.
                                 $quantity = floor($quantity / $discount->lower_limit);
 
@@ -497,7 +493,6 @@ class OrderFactory implements OrderFactoryInterface
                                 $taxable = $lineTotal - $discountTotal;
 
                                 $tax = $this->tax->amount($taxable);
-
 
                                 $order->lines()->create([
                                     'sku' => $variant->sku,

--- a/src/Core/Orders/Models/Order.php
+++ b/src/Core/Orders/Models/Order.php
@@ -69,6 +69,7 @@ class Order extends BaseModel
         if (! $zone) {
             return $qb;
         }
+
         return $qb->whereHas('lines', function ($q) use ($zone) {
             return $q->where('option', '=', $zone);
         });

--- a/src/Core/Orders/Services/OrderService.php
+++ b/src/Core/Orders/Services/OrderService.php
@@ -406,7 +406,7 @@ class OrderService extends BaseService implements OrderServiceInterface
     {
         $order = $this->getByHashedId($id);
 
-        if (!empty($data['vat_no'])) {
+        if (! empty($data['vat_no'])) {
             $order->vat_no = $data['vat_no'];
         }
 

--- a/src/Core/Payments/PaymentManager.php
+++ b/src/Core/Payments/PaymentManager.php
@@ -45,7 +45,7 @@ class PaymentManager extends Manager implements PaymentContract
         );
     }
 
-        /**
+    /**
      * Create the sagepay driver.
      *
      * @return SagePay

--- a/src/Core/Payments/Providers/Braintree.php
+++ b/src/Core/Payments/Providers/Braintree.php
@@ -129,6 +129,7 @@ class Braintree extends AbstractProvider
         $response->transaction(
             $this->createTransaction($sale, $this->order)
         );
+
         return $response;
     }
 

--- a/src/Core/Payments/Providers/SagePay.php
+++ b/src/Core/Payments/Providers/SagePay.php
@@ -49,7 +49,7 @@ class SagePay extends AbstractProvider
                 'description' => $description,
             ];
 
-            $response = $this->http->post($this->host . 'transactions', [
+            $response = $this->http->post($this->host.'transactions', [
                 'headers' => [
                     'Authorization' => 'Basic '.$this->getCredentials(),
                     'Content-Type' => 'application/json',
@@ -115,7 +115,7 @@ class SagePay extends AbstractProvider
             }
 
             // \Log::info(json_encode($payload));
-            $response = $this->http->post($this->host . 'transactions', [
+            $response = $this->http->post($this->host.'transactions', [
                 'headers' => [
                     'Authorization' => 'Basic '.$this->getCredentials(),
                     'Content-Type' => 'application/json',
@@ -123,7 +123,6 @@ class SagePay extends AbstractProvider
                 ],
                 'json' => $payload,
             ]);
-
         } catch (ClientException $e) {
             $errors = json_decode($e->getResponse()->getBody()->getContents(), true);
             $response = new PaymentResponse(false, 'Payment Failed', $errors);
@@ -193,6 +192,7 @@ class SagePay extends AbstractProvider
             ]);
         } catch (ClientException $e) {
             $errors = json_decode($e->getResponse()->getBody()->getContents(), true);
+
             return $this->createFailedTransaction([
                 'statusDetail' => $errors['description'],
                 'status' => 'failed',
@@ -329,7 +329,7 @@ class SagePay extends AbstractProvider
     public function getClientToken()
     {
         try {
-            $response = $this->http->post($this->host . 'merchant-session-keys', [
+            $response = $this->http->post($this->host.'merchant-session-keys', [
                 'headers' => [
                     'Authorization' => 'Basic '.$this->getCredentials(),
                     'Content-Type' => 'application/json',
@@ -341,6 +341,7 @@ class SagePay extends AbstractProvider
             ]);
         } catch (ClientException $e) {
             Log::error($e->getMessage());
+
             return;
         }
 

--- a/src/Core/Products/Services/ProductService.php
+++ b/src/Core/Products/Services/ProductService.php
@@ -303,7 +303,6 @@ class ProductService extends BaseService
             'primaryAsset.source',
         ])->whereIn('id', $parsedIds);
 
-
         if (count($parsedIds)) {
             $query = $query->orderByRaw("field(id,{$placeholders})", $parsedIds);
         }

--- a/src/Core/Search/Providers/Elastic/Indexer.php
+++ b/src/Core/Search/Providers/Elastic/Indexer.php
@@ -184,7 +184,7 @@ class Indexer
         $indexables = $type->getIndexDocument($model);
 
         foreach ($langs as $lang) {
-            $alias = $index . '_' . $lang->lang;
+            $alias = $index.'_'.$lang->lang;
 
             $indices = $status->getIndicesWithAlias($alias);
 
@@ -222,7 +222,7 @@ class Indexer
             $indexables = $type->getIndexDocument($model);
 
             foreach ($langs as $lang) {
-                $alias = $index . '_' . $lang->lang;
+                $alias = $index.'_'.$lang->lang;
 
                 $indices = $status->getIndicesWithAlias($alias);
 
@@ -329,8 +329,6 @@ class Indexer
             $this->reset($alias."_{$remove}");
         }
     }
-
-
 
     /**
      * Add a single model to the elastic index.

--- a/src/Core/Search/Providers/Elastic/Indexer.php
+++ b/src/Core/Search/Providers/Elastic/Indexer.php
@@ -30,9 +30,9 @@ class Indexer
      */
     protected $resolver;
 
-    public function __construct(Client $client, LanguageService $lang, IndiceResolver $resolver)
+    public function __construct(LanguageService $lang, IndiceResolver $resolver)
     {
-        $this->client = $client;
+        $this->client = new Client(config('getcandy.search.client_config.elastic', []));
         $this->lang = $lang;
         $this->resolver = $resolver;
     }

--- a/src/Core/Search/Providers/Elastic/SearchBuilder.php
+++ b/src/Core/Search/Providers/Elastic/SearchBuilder.php
@@ -116,7 +116,7 @@ class SearchBuilder
         $this->filters = collect($this->filters);
         $this->aggregations = collect($this->aggregations);
         $this->sorts = collect($this->sorts);
-        $this->client = new Client;
+        $this->client = new Client(config('getcandy.search.client_config.elastic', []));
         $this->attributes = $attributes->all();
     }
 

--- a/src/Core/Shipping/Providers/RegionalProvider.php
+++ b/src/Core/Shipping/Providers/RegionalProvider.php
@@ -12,7 +12,6 @@ class RegionalProvider extends AbstractProvider
         $prices = $this->method->prices;
 
         $prices = $this->method->prices->filter(function ($price) use ($order) {
-
             $region = $price->zone->regions->first(function ($region) use ($order) {
                 $postcode = strtoupper($order->shippingDetails['zip']);
                 $outcode = rtrim(substr($postcode, 0, -3));
@@ -25,7 +24,6 @@ class RegionalProvider extends AbstractProvider
 
             return (bool) $region;
         });
-
 
         if (! $prices->count()) {
 
@@ -42,7 +40,6 @@ class RegionalProvider extends AbstractProvider
             }
         }
 
-
         $user = $basket->user;
         $price = $prices->filter(function ($item) use ($weight, $basket, $user, $users, $order) {
             if ($users->contains($user)) {
@@ -51,7 +48,7 @@ class RegionalProvider extends AbstractProvider
                 return false;
             }
 
-            if (!$item->min_basket || $basket->sub_total > ($item->min_basket / 100) && $weight >= $item->min_weight) {
+            if (! $item->min_basket || $basket->sub_total > ($item->min_basket / 100) && $weight >= $item->min_weight) {
                 return $item;
             }
         })->sortBy('rate')->first();

--- a/src/Core/Shipping/Services/ShippingMethodService.php
+++ b/src/Core/Shipping/Services/ShippingMethodService.php
@@ -7,7 +7,6 @@ use GetCandy\Api\Core\Shipping\ShippingCalculator;
 use GetCandy\Api\Core\Baskets\Services\BasketService;
 use GetCandy\Api\Core\Shipping\Models\ShippingMethod;
 use GetCandy\Api\Core\Attributes\Events\AttributableSavedEvent;
-use GetCandy\Api\Core\Channels\Interfaces\ChannelFactoryInterface;
 
 class ShippingMethodService extends BaseService
 {
@@ -119,8 +118,6 @@ class ShippingMethodService extends BaseService
                 }
             }
         }
-
-
 
         return collect($options);
     }

--- a/src/Http/Middleware/SetCustomerGroups.php
+++ b/src/Http/Middleware/SetCustomerGroups.php
@@ -16,7 +16,7 @@ class SetCustomerGroups
      */
     public function handle($request, Closure $next)
     {
-        if (($user = $request->user()) && !count(GetCandy::getGroups())) {
+        if (($user = $request->user()) && ! count(GetCandy::getGroups())) {
             // Are we an admin?
             if ($user->hasRole('admin')) {
                 $groups = app('api')->customerGroups()->all();

--- a/tests/Feature/FeatureCase.php
+++ b/tests/Feature/FeatureCase.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use Tests\Stubs\User;
 use Laravel\Passport\Client;
 
 abstract class FeatureCase extends TestCase
@@ -17,6 +16,7 @@ abstract class FeatureCase extends TestCase
         if ($user) {
             return $this->getUserToken();
         }
+
         return $this->getClientToken();
     }
 
@@ -27,7 +27,6 @@ abstract class FeatureCase extends TestCase
         }
 
         $client = Client::first();
-
 
         dd($client);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,7 +67,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             ],
             'sagepay' => [
                 'vendor' => 'SagePay',
-            ]
+            ],
         ]);
     }
 

--- a/tests/Unit/Orders/Factories/OrderFactoryTest.php
+++ b/tests/Unit/Orders/Factories/OrderFactoryTest.php
@@ -219,7 +219,6 @@ class OrderFactoryTest extends TestCase
             'currency' => 'GBP',
         ]);
 
-
         \GetCandy\Api\Core\Baskets\Models\BasketLine::forceCreate([
             'product_variant_id' => $variant->id,
             'basket_id' => $basket->id,
@@ -266,9 +265,7 @@ class OrderFactoryTest extends TestCase
 
         $this->assertCount(1, $basket->discounts);
 
-
         $basket = $this->app->make(BasketFactory::class)->init($basket)->get();
-
 
         $order = $factory->basket($basket)->resolve();
 

--- a/tests/Unit/Payments/Providers/SagePayTest.php
+++ b/tests/Unit/Payments/Providers/SagePayTest.php
@@ -6,15 +6,15 @@ use Event;
 use Mockery;
 use Tests\TestCase;
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Stream\Stream;
-use GetCandy\Api\Core\Payments\PaymentContract;
-use GetCandy\Api\Core\Payments\Providers\SagePay;
-use GetCandy\Api\Core\Orders\Factories\OrderFactory;
 use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
+use GetCandy\Api\Core\Payments\PaymentContract;
 use GetCandy\Api\Core\Payments\PaymentResponse;
+use GetCandy\Api\Core\Payments\Providers\SagePay;
 use GetCandy\Api\Core\Payments\Models\Transaction;
+use GetCandy\Api\Core\Orders\Factories\OrderFactory;
 use GetCandy\Api\Core\Payments\ThreeDSecureResponse;
 
 /**
@@ -31,7 +31,6 @@ class SagePayTest extends TestCase
     public function test_can_get_client_token()
     {
         // Get our required response
-
 
         // Mock up our client
         $client = Mockery::mock('GuzzleHttp\Client');
@@ -57,7 +56,7 @@ class SagePayTest extends TestCase
         // Mock up our client
         $mock = new MockHandler([
             $this->getMerchantTokenResponse(),
-            $this->getSuccessfulChargeResponse($order->order_total)
+            $this->getSuccessfulChargeResponse($order->order_total),
         ]);
 
         $handler = HandlerStack::create($mock);
@@ -143,7 +142,6 @@ class SagePayTest extends TestCase
             'paRequest' => 1234,
         ], $result->params());
 
-
         $threed = $sagepay->processThreeD('TEST_TRANSACTION', 1234);
 
         $this->assertTrue($threed->success);
@@ -184,7 +182,7 @@ class SagePayTest extends TestCase
     }
 
     /**
-     * Gets a mocked threed secure response
+     * Gets a mocked threed secure response.
      *
      * @return Response
      */
@@ -193,11 +191,12 @@ class SagePayTest extends TestCase
         $body = Stream::factory(json_encode([
             'status' => 'Authenticated',
         ]));
+
         return new Response(200, [], $body);
     }
 
     /**
-     * Get a refund response
+     * Get a refund response.
      *
      * @return Response
      */
@@ -209,15 +208,16 @@ class SagePayTest extends TestCase
             'paymentMethod' => [
                 'card' => [
                     'cardType' => 'Visa',
-                    'lastFourDigits' => 1234
-                ]
-            ]
+                    'lastFourDigits' => 1234,
+                ],
+            ],
         ]));
+
         return new Response(200, [], $body);
     }
 
     /**
-     * Returns a mocked merchant token response
+     * Returns a mocked merchant token response.
      *
      * @return Response
      */
@@ -227,13 +227,14 @@ class SagePayTest extends TestCase
             'expiry' => null,
             'merchantSessionKey' => 'TEST_MERCHANT_KEY',
         ]));
+
         return new Response(200, [], $body);
     }
 
     /**
-     * Returns a mocked successful charge response
+     * Returns a mocked successful charge response.
      *
-     * @param integer $amount
+     * @param int $amount
      * @return Response
      */
     protected function getSuccessfulChargeResponse($amount = 10, $extra = [])
@@ -250,7 +251,7 @@ class SagePayTest extends TestCase
                 'card' => [
                     'cardType' => 'Mastercard',
                     'lastFourDigits' => '1234',
-                ]
+                ],
             ],
             '3DSecure' => [
                 'status' => false,

--- a/tests/Unit/Shipping/Services/ShippingMethodServiceTest.php
+++ b/tests/Unit/Shipping/Services/ShippingMethodServiceTest.php
@@ -18,8 +18,6 @@ use GetCandy\Api\Core\Shipping\Services\ShippingMethodService;
  */
 class ShippingMethodServiceTest extends TestCase
 {
-
-
     public function test_can_get_correct_shipping_methods()
     {
         $country = Country::forceCreate([
@@ -122,7 +120,6 @@ class ShippingMethodServiceTest extends TestCase
                     'visible' => 1,
                 ]);
             }
-
 
             $price = new ShippingPrice;
             $price->rate = 795;


### PR DESCRIPTION
This change allows you to add config to the Elastic search client. Since these options are potentially just specifc to elastic, I namespaced them, at then you could have `agolia` and `elastic` config side by side in the future and swapping search drivers would cause minimal disruption, the config looks like so:


```php
// Rest of getcandy.php config
    'search' => [
        'client_config' => [
            'elastic' => [
                'host' => null,
                'port' => null,
                'path' => null,
                'url' => null,
                'proxy' => null,
                'transport' => null,
                'persistent' => true,
                'timeout' => null,
                'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
                'roundRobin' => false,
                'log' => false,
                'retryOnConflict' => 0,
                'bigintConversion' => false,
                'username' => null,
                'password' => null,
            ]
        ],
    ]
```

These are the defaults provided by the client any, just added them all to the default getcandy config as a means to show what's there.