### PR TITLE
Product pricing tier belongs to relation needs to define the foreign key

### DIFF
--- a/src/Core/Products/Models/ProductPricingTier.php
+++ b/src/Core/Products/Models/ProductPricingTier.php
@@ -72,7 +72,7 @@ class ProductPricingTier extends BaseModel
 
     public function variant()
     {
-        return $this->belongsTo(ProductVariant::class);
+        return $this->belongsTo(ProductVariant::class, 'product_variant_id');
     }
 
     public function group()


### PR DESCRIPTION
It seems like this does not work without specifying the foreign key explicitly.