### PR TITLE
Fix table name in drop statement

### DIFF
--- a/database/migrations/2020_01_15_161140_add_path_to_routes.php
+++ b/database/migrations/2020_01_15_161140_add_path_to_routes.php
@@ -21,7 +21,7 @@ class AddPathToRoutes extends Migration
 
     public function down()
     {
-        Schema::table('order_lines', function (Blueprint $table) {
+        Schema::table('routes', function (Blueprint $table) {
             $table->dropColumn('path');
             $table->index('slug');
         });


### PR DESCRIPTION
Hey guys,

Looks like there's 2 problems with one of the migration files.

The first is that the table name in the drop statement is `order_lines` when it should be `routes`, and this PR fixes that.

The second is that the filename is 2020. I'm hesitant to change that as it will break existing migrations