### PR TITLE
pass the language to the search builder

### DIFF
--- a/src/Core/Search/Providers/Elastic/Search.php
+++ b/src/Core/Search/Providers/Elastic/Search.php
@@ -167,7 +167,7 @@ class Search implements ClientContract
      */
     public function language($lang = 'en')
     {
-        $this->lang = $lang;
+        $this->builder->setLang($lang);
 
         return $this;
     }

--- a/src/Core/Search/Providers/Elastic/SearchBuilder.php
+++ b/src/Core/Search/Providers/Elastic/SearchBuilder.php
@@ -134,6 +134,19 @@ class SearchBuilder
     }
 
     /**
+     * Set the language.
+     *
+     * @param $lang
+     * @return SearchBuilder
+     */
+    public function setLang($lang)
+    {
+        $this->lang = $lang;
+
+        return $this;
+    }
+
+    /**
      * Set the search term.
      *
      * @param string $term


### PR DESCRIPTION
After having some issues with the translation of search results, the following fixed it for me. In the PR the lang is set on the builder instead of the client. Does this make sense?