### PR TITLE
Move processOrder logic from OrderController to a trait

### DIFF
--- a/src/Core/Traits/CanProcessOrder.php
+++ b/src/Core/Traits/CanProcessOrder.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace GetCandy\Api\Core\Traits;
+
+use GetCandy\Api\Core\Payments\Models\PaymentType;
+use GetCandy\Api\Http\Resources\Orders\OrderResource;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use GetCandy\Api\Core\Payments\Services\PaymentTypeService;
+use GetCandy\Api\Http\Resources\Payments\ThreeDSecureResource;
+use GetCandy\Api\Core\Orders\Interfaces\OrderCriteriaInterface;
+use GetCandy\Api\Core\Orders\Exceptions\IncompleteOrderException;
+use GetCandy\Api\Core\Orders\Exceptions\OrderAlreadyProcessedException;
+use GetCandy\Api\Core\Orders\Interfaces\OrderProcessingFactoryInterface;
+use GetCandy\Api\Core\Payments\Exceptions\ThreeDSecureRequiredException;
+
+trait CanProcessOrder
+{
+    /**
+     * @param int $orderId
+     * @param array $orderData
+     *
+     * @return OrderResource|ThreeDSecureResource|Response
+     */
+    public function processOrder(int $orderId, array $orderData)
+    {
+        $factory = app(OrderProcessingFactoryInterface::class);
+        $criteria = app(OrderCriteriaInterface::class);
+
+        try {
+            $paymentType = $this->getPaymentType($orderData);
+
+            $order = $criteria->id($orderId)->first();
+
+            if (! $order) {
+                if ($this->isOrderAlreadyProcessed($orderId)) {
+                    throw new OrderAlreadyProcessedException;
+                }
+            }
+
+            $order = $factory
+                ->order($order)
+                ->provider($paymentType)
+                ->nonce($orderData['payment_token'])
+                ->type($orderData['type'])
+                ->customerReference($orderData['customer_reference'])
+                ->meta($orderData['meta'] ?? [])
+                ->notes($orderData['notes'])
+                ->payload($orderData['data'] ?: [])
+                ->resolve();
+
+            if (! $order->placed_at) {
+                return $this->errorForbidden('Payment has failed');
+            }
+
+            return new OrderResource($order);
+        } catch (IncompleteOrderException $e) {
+            return $this->errorForbidden('The order is missing billing information');
+        } catch (ModelNotFoundException $e) {
+            return $this->errorNotFound();
+        } catch (OrderAlreadyProcessedException $e) {
+            return $this->errorUnprocessable('This order has already been processed');
+        } catch (ThreeDSecureRequiredException $e) {
+            return new ThreeDSecureResource($e->getResponse());
+        }
+    }
+
+    /**
+     * The order type may be passed by ID or by handle, so this method
+     * identifies which, and then calls the correct method to retrieve it.
+     *
+     * @param array $orderData
+     *
+     * @return PaymentType|null
+     */
+    private function getPaymentType(array $orderData): ?PaymentType
+    {
+        $paymentTypes = app(PaymentTypeService::class);
+
+        if ($orderData['payment_type_id']) {
+            return $paymentTypes->getByHashedId($orderData['payment_type_id']);
+        }
+
+        if ($orderData['payment_type']) {
+            return $paymentTypes->getByHandle($orderData['payment_type']);
+        }
+
+        return null;
+    }
+
+    private function isOrderAlreadyProcessed(int $orderId): bool
+    {
+        $criteria = app(OrderCriteriaInterface::class);
+
+        $placedOrder = $criteria->id($orderId)->getBuilder()->withoutGlobalScopes()->first();
+        if ($placedOrder && $placedOrder->placed_at) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Http/Controllers/Orders/OrderController.php
+++ b/src/Http/Controllers/Orders/OrderController.php
@@ -2,9 +2,9 @@
 
 namespace GetCandy\Api\Http\Controllers\Orders;
 
-use GetCandy\Api\Core\Traits\CanProcessOrder;
 use Illuminate\Http\Request;
 use GetCandy\Api\Core\Orders\OrderExport;
+use GetCandy\Api\Core\Traits\CanProcessOrder;
 use GetCandy\Api\Http\Controllers\BaseController;
 use GetCandy\Api\Http\Resources\Files\PdfResource;
 use GetCandy\Api\Http\Requests\Orders\CreateRequest;
@@ -163,7 +163,8 @@ class OrderController extends BaseController
      *
      * @return OrderResource|ThreeDSecureResource|Response
      */
-    public function process(ProcessRequest $request) {
+    public function process(ProcessRequest $request)
+    {
         return $this->processOrder($request->order_id, $request->toArray());
     }
 

--- a/src/Http/Controllers/Orders/OrderController.php
+++ b/src/Http/Controllers/Orders/OrderController.php
@@ -15,7 +15,6 @@ use GetCandy\Api\Http\Resources\Orders\OrderCollection;
 use GetCandy\Api\Http\Requests\Orders\BulkUpdateRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use GetCandy\Api\Http\Requests\Orders\StoreAddressRequest;
-use GetCandy\Api\Core\Payments\Services\PaymentTypeService;
 use GetCandy\Api\Http\Resources\Orders\OrderExportResource;
 use GetCandy\Api\Core\Shipping\Services\ShippingPriceService;
 use GetCandy\Api\Core\Orders\Interfaces\OrderFactoryInterface;
@@ -25,13 +24,9 @@ use GetCandy\Api\Http\Resources\Payments\ThreeDSecureResource;
 use GetCandy\Api\Core\Orders\Interfaces\OrderCriteriaInterface;
 use GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface;
 use GetCandy\Api\Core\Baskets\Interfaces\BasketCriteriaInterface;
-use GetCandy\Api\Core\Orders\Exceptions\IncompleteOrderException;
 use GetCandy\Api\Http\Resources\Shipping\ShippingPriceCollection;
 use GetCandy\Api\Http\Requests\Orders\Shipping\AddShippingRequest;
 use GetCandy\Api\Core\Orders\Exceptions\BasketHasPlacedOrderException;
-use GetCandy\Api\Core\Orders\Exceptions\OrderAlreadyProcessedException;
-use GetCandy\Api\Core\Orders\Interfaces\OrderProcessingFactoryInterface;
-use GetCandy\Api\Core\Payments\Exceptions\ThreeDSecureRequiredException;
 
 class OrderController extends BaseController
 {


### PR DESCRIPTION
There is a lot of logic for processing an order in the OrderController.

This is fair and fine, but it prevents users of candy from being able
to prepend or append their own order logic for processing an order.

I'd like to present two solutions to this: #155 (this) and #156 (the order service).

Moving this logic to a trait allows others to override the process order
endpoint to point to their own OrderController, and, by including the trait,
continue processing the order using Candy's logic.