### PR TITLE
Add partial SKU match when searching

### DIFF
--- a/src/Core/Search/Providers/Elastic/Query/Term.php
+++ b/src/Core/Search/Providers/Elastic/Query/Term.php
@@ -4,6 +4,7 @@ namespace GetCandy\Api\Core\Search\Providers\Elastic\Query;
 
 use Elastica\Query\DisMax;
 use Elastica\Query\MultiMatch;
+use Elastica\Query\Wildcard;
 
 class Term
 {
@@ -63,6 +64,10 @@ class Term
                 }
             }
         }
+
+        $skuTerm = strtolower($this->text);
+        $wildcard = new Wildcard('sku.lowercase', "*{$skuTerm}*");
+        $disMaxQuery->addQuery($wildcard);
 
         return $disMaxQuery;
     }


### PR DESCRIPTION
@glennjacobs 

This would allow you to search by partial SKU on the API, this creates a better experience for example when searching within the Hub, as you don't have to do the entire SKU to find the product.

Also means if you do a partial SKU search it'll give more potentially related products.

I don't think it'll create any adverse effects to searching in general, but figured I'd get your thoughts :)