### PR TITLE
Bug: Fix schema to drop min_batch col from correct product_variants table

### DIFF
--- a/database/migrations/2019_03_25_122100_add_min_batch_to_variants_table.php
+++ b/database/migrations/2019_03_25_122100_add_min_batch_to_variants_table.php
@@ -20,7 +20,7 @@ class AddMinBatchToVariantsTable extends Migration
 
     public function down()
     {
-        Schema::table('order_lines', function (Blueprint $table) {
+        Schema::table('product_variants', function (Blueprint $table) {
             $table->dropColumn('min_batch');
         });
     }


### PR DESCRIPTION
Issue: In Add min_batch column to product_variants schema, schema attempts to drop column from incorrect order_lines table. This is currently causing rollback to break.

Fix: Add correct product_variants table in drop schema.