### PR TITLE
Fix unparenthesized nested ternary operator

### DIFF
--- a/src/Http/Controllers/Search/SearchController.php
+++ b/src/Http/Controllers/Search/SearchController.php
@@ -39,7 +39,7 @@ class SearchController extends BaseController
     {
         // Get channel
         $defaultChannel = $this->channels->getDefaultRecord();
-        $channel = $request->channel ?: $defaultChannel ? $defaultChannel->handle : null;
+        $channel = $request->channel ?: ($defaultChannel ? $defaultChannel->handle : null);
 
         try {
             $categories = $this->categories->getByHashedIds(


### PR DESCRIPTION
Starting with PHP 7.4 it's been deprecated nested ternary operators without explicit parentheses.
See notice [here](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary).

This PR fixes a nested ternary operator in `SearchController.php` when filtering a search by channel.

The way I've encountered with this deprecation was by running `php artisan r:l`, I got the following output:
```
➜  candy-api git:(master) ✗ php artisan r:l

   ErrorException

  Unparenthesized `a ?: b ? c : d` is deprecated. Use either `(a ?: b) ? c : d` or `a ?: (b ? c : d)`

  at vendor/getcandy/candy-api/src/Http/Controllers/Search/SearchController.php:42
    38|     public function search(SearchRequest $request, SearchContract $search)
    39|     {
    40|         // Get channel
    41|         $defaultChannel = $this->channels->getDefaultRecord();
  > 42|         $channel = $request->channel ?: $defaultChannel ? $defaultChannel->handle : null;
    43|
    44|         try {
    45|             $categories = $this->categories->getByHashedIds(
    46|                 explode(':', $request->category)

      +3 vendor frames
  4   [internal]:0
      Composer\Autoload\ClassLoader::loadClass()

  5   [internal]:0
      spl_autoload_call()
```