### PR TITLE
Remove old references to Laravel Passport

### DIFF
--- a/src/Core/Auth/Models/User.php
+++ b/src/Core/Auth/Models/User.php
@@ -13,14 +13,12 @@ use GetCandy\Plugins\LegacyPassword\Models\LegacyPassword;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Laravel\Passport\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     use Notifiable,
         Hashids,
-        HasApiTokens,
         HasRoles;
 
     protected $hashids = 'user';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,6 @@ use Illuminate\Database\Schema\SQLiteBuilder;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Fluent;
-use Laravel\Passport\PassportServiceProvider;
 use NeonDigital\Drafting\DraftingServiceProvider;
 use NeonDigital\Versioning\VersioningServiceProvider;
 use Spatie\Activitylog\ActivitylogServiceProvider;
@@ -127,7 +126,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getPackageProviders($app)
     {
         return [
-            PassportServiceProvider::class,
             ApiServiceProvider::class,
             PermissionServiceProvider::class,
             ActivitylogServiceProvider::class,


### PR DESCRIPTION
Since Laravel Passport is no longer a dependency, this PR removes old references to the package.