### PR TITLE
Fixed wrong namespace for MinimumRecordRequiredException

### DIFF
--- a/src/Core/Attributes/Services/AttributeGroupService.php
+++ b/src/Core/Attributes/Services/AttributeGroupService.php
@@ -77,7 +77,7 @@ class AttributeGroupService extends BaseService
      * @param  array  $data
      *
      * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws GetCandy\Api\Core\Exceptions\MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
      * @return GetCandy\Api\Core\Models\AttributeGroup
      */

--- a/src/Core/Channels/Services/ChannelService.php
+++ b/src/Core/Channels/Services/ChannelService.php
@@ -4,7 +4,7 @@ namespace GetCandy\Api\Core\Channels\Services;
 
 use GetCandy\Api\Core\Channels\Models\Channel;
 use GetCandy\Api\Core\Scaffold\BaseService;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 
 class ChannelService extends BaseService
 {
@@ -59,7 +59,7 @@ class ChannelService extends BaseService
      * @param  array  $data
      *
      * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws GetCandy\Api\Core\Exceptions\MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
      * @return GetCandy\Api\Core\Models\Channel
      */
@@ -85,7 +85,7 @@ class ChannelService extends BaseService
     /**
      * @param $id
      * @return mixed
-     * @throws MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      */
     public function delete($id)
     {

--- a/src/Core/Currencies/Services/CurrencyService.php
+++ b/src/Core/Currencies/Services/CurrencyService.php
@@ -5,7 +5,7 @@ namespace GetCandy\Api\Core\Currencies\Services;
 use GetCandy\Api\Core\Currencies\Interfaces\CurrencyServiceInterface;
 use GetCandy\Api\Core\Currencies\Models\Currency;
 use GetCandy\Api\Core\Scaffold\BaseService;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 
 class CurrencyService extends BaseService implements CurrencyServiceInterface
 {
@@ -58,7 +58,7 @@ class CurrencyService extends BaseService implements CurrencyServiceInterface
      * @param  array  $data
      *
      * @throws Symfony\Component\HttpKernel\Exception
-     * @throws GetCandy\Api\Core\Exceptions\MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
      * @return GetCandy\Api\Core\Models\Currency
      */
@@ -104,7 +104,7 @@ class CurrencyService extends BaseService implements CurrencyServiceInterface
      * @param  string $id
      *
      * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws GetCandy\Api\Core\Exceptions\MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
      * @return bool
      */

--- a/src/Core/Languages/Services/LanguageService.php
+++ b/src/Core/Languages/Services/LanguageService.php
@@ -4,7 +4,7 @@ namespace GetCandy\Api\Core\Languages\Services;
 
 use GetCandy\Api\Core\Languages\Models\Language;
 use GetCandy\Api\Core\Scaffold\BaseService;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 
 class LanguageService extends BaseService
 {
@@ -52,7 +52,7 @@ class LanguageService extends BaseService
      * @param  array  $data
      *
      * @throws Symfony\Component\HttpKernel\Exception
-     * @throws GetCandy\Api\Core\Exceptions\MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
      * @return GetCandy\Api\Core\Models\Language
      */
@@ -102,7 +102,7 @@ class LanguageService extends BaseService
      * @param  string $id
      *
      * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws GetCandy\Api\Core\Exceptions\MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
      * @return bool
      */

--- a/src/Core/Routes/Services/RouteService.php
+++ b/src/Core/Routes/Services/RouteService.php
@@ -50,7 +50,7 @@ class RouteService extends BaseService
     /**
      * @param $hashedId
      * @return mixed
-     * @throws MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      */
     public function delete($hashedId)
     {

--- a/src/Core/Taxes/Services/TaxService.php
+++ b/src/Core/Taxes/Services/TaxService.php
@@ -79,7 +79,7 @@ class TaxService extends BaseService
      * @param  string $id
      *
      * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws GetCandy\Api\Core\Exceptions\MinimumRecordRequiredException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
      * @return bool
      */

--- a/src/Http/Controllers/Attributes/AttributeController.php
+++ b/src/Http/Controllers/Attributes/AttributeController.php
@@ -10,6 +10,7 @@ use GetCandy\Api\Http\Requests\Attributes\ReorderRequest;
 use GetCandy\Api\Http\Requests\Attributes\UpdateRequest;
 use GetCandy\Api\Http\Resources\Attributes\AttributeCollection;
 use GetCandy\Api\Http\Resources\Attributes\AttributeResource;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Http/Controllers/Attributes/AttributeGroupController.php
+++ b/src/Http/Controllers/Attributes/AttributeGroupController.php
@@ -10,6 +10,7 @@ use GetCandy\Api\Http\Requests\AttributeGroups\UpdateRequest;
 use GetCandy\Api\Http\Resources\Attributes\AttributeGroupCollection;
 use GetCandy\Api\Http\Resources\Attributes\AttributeGroupResource;
 use GetCandy\Api\Http\Transformers\Fractal\Attributes\AttributeGroupTransformer;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use GetCandy\Exceptions\DuplicateValueException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;

--- a/src/Http/Controllers/Categories/CategoryController.php
+++ b/src/Http/Controllers/Categories/CategoryController.php
@@ -14,6 +14,7 @@ use GetCandy\Api\Http\Requests\Categories\UpdateRequest;
 use GetCandy\Api\Http\Resources\Categories\CategoryCollection;
 use GetCandy\Api\Http\Resources\Categories\CategoryResource;
 use GetCandy\Api\Http\Transformers\Fractal\Categories\CategoryTransformer;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Hashids;
 use Illuminate\Http\Request;
 use Intervention\Image\Exception\NotFoundException;

--- a/src/Http/Controllers/Channels/ChannelController.php
+++ b/src/Http/Controllers/Channels/ChannelController.php
@@ -9,7 +9,7 @@ use GetCandy\Api\Http\Requests\Channels\UpdateRequest;
 use GetCandy\Api\Http\Resources\Channels\ChannelCollection;
 use GetCandy\Api\Http\Resources\Channels\ChannelResource;
 use GetCandy\Api\Http\Transformers\Fractal\Channels\ChannelTransformer;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Http/Controllers/Currencies/CurrencyController.php
+++ b/src/Http/Controllers/Currencies/CurrencyController.php
@@ -7,7 +7,7 @@ use GetCandy\Api\Http\Requests\Currencies\CreateRequest;
 use GetCandy\Api\Http\Requests\Currencies\DeleteRequest;
 use GetCandy\Api\Http\Requests\Currencies\UpdateRequest;
 use GetCandy\Api\Http\Transformers\Fractal\Currencies\CurrencyTransformer;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Http/Controllers/Languages/LanguageController.php
+++ b/src/Http/Controllers/Languages/LanguageController.php
@@ -9,7 +9,7 @@ use GetCandy\Api\Http\Requests\Languages\UpdateRequest;
 use GetCandy\Api\Http\Resources\Languages\LanguageCollection;
 use GetCandy\Api\Http\Resources\Languages\LanguageResource;
 use GetCandy\Api\Http\Transformers\Fractal\Languages\LanguageTransformer;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Http/Controllers/Products/ProductController.php
+++ b/src/Http/Controllers/Products/ProductController.php
@@ -18,7 +18,7 @@ use GetCandy\Api\Http\Resources\Products\ProductRecommendationCollection;
 use GetCandy\Api\Http\Resources\Products\ProductResource;
 use GetCandy\Api\Http\Transformers\Fractal\Products\ProductTransformer;
 use GetCandy\Exceptions\InvalidLanguageException;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Hashids;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;

--- a/src/Http/Controllers/Products/ProductFamilyController.php
+++ b/src/Http/Controllers/Products/ProductFamilyController.php
@@ -11,7 +11,7 @@ use GetCandy\Api\Http\Resources\Products\ProductFamilyCollection;
 use GetCandy\Api\Http\Resources\Products\ProductFamilyResource;
 use GetCandy\Api\Http\Transformers\Fractal\Products\ProductFamilyTransformer;
 use GetCandy\Exceptions\InvalidLanguageException;
-use GetCandy\Exceptions\MinimumRecordRequiredException;
+use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;


### PR DESCRIPTION
By looking at the code I noticed the exception `MinimumRecordRequiredException` had the wrong namespace imported in many classes, I assume it changed recently but it wasn't updated throughout the codebase.

I searched all coincidences in files and updated them accordingly, also imported the exception to a few other classes as it was being used there but not imported at the top.

There might be more PRs coming for Docblock issues and wrong imports that I've found but still need to get to them.

