### PR TITLE
[WIP] Improving DocBlocks

### DIFF
--- a/src/Console/Commands/CandySearchIndexCommand.php
+++ b/src/Console/Commands/CandySearchIndexCommand.php
@@ -24,6 +24,11 @@ class CandySearchIndexCommand extends Command
      */
     protected $description = 'Reindexes the search';
 
+    /**
+     * The models that should be indexed.
+     *
+     * @var array
+     */
     protected $indexables = [
         Product::class,
         Category::class,

--- a/src/Core/ActivityLog/Factories/ActivityLogFactory.php
+++ b/src/Core/ActivityLog/Factories/ActivityLogFactory.php
@@ -10,7 +10,7 @@ class ActivityLogFactory implements ActivityLogFactoryInterface
     /**
      * The related model.
      *
-     * @var Model
+     * @var \Illuminate\Database\Eloquent\Model
      */
     protected $model;
 
@@ -38,8 +38,8 @@ class ActivityLogFactory implements ActivityLogFactoryInterface
     /**
      * Set the model.
      *
-     * @param Model $model
-     * @return self
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return $this
      */
     public function against(Model $model)
     {
@@ -51,8 +51,8 @@ class ActivityLogFactory implements ActivityLogFactoryInterface
     /**
      * Set the value for action.
      *
-     * @param string $action
-     * @return self
+     * @param  string  $action
+     * @return $this
      */
     public function action($action)
     {
@@ -64,8 +64,8 @@ class ActivityLogFactory implements ActivityLogFactoryInterface
     /**
      * Set any additional properties.
      *
-     * @param array $properties
-     * @return self
+     * @param  array  $properties
+     * @return $this
      */
     public function with($properties = [])
     {
@@ -77,8 +77,8 @@ class ActivityLogFactory implements ActivityLogFactoryInterface
     /**
      * Set the value for user.
      *
-     * @param Model $user
-     * @return self
+     * @param  null|\Illuminate\Database\Eloquent\Model $user
+     * @return $this
      */
     public function as(Model $user = null)
     {
@@ -90,7 +90,7 @@ class ActivityLogFactory implements ActivityLogFactoryInterface
     /**
      * Log the action.
      *
-     * @param string $type
+     * @param  string  $type
      * @return void
      */
     public function log($type = 'default')

--- a/src/Core/ActivityLog/Interfaces/ActivityLogFactoryInterface.php
+++ b/src/Core/ActivityLog/Interfaces/ActivityLogFactoryInterface.php
@@ -7,7 +7,7 @@ interface ActivityLogFactoryInterface
     /**
      * Log the action.
      *
-     * @param string $type
+     * @param  string  $type
      * @return void
      */
     public function log($type = 'default');

--- a/src/Core/ActivityLog/Listeners/Orders/LogRefundListener.php
+++ b/src/Core/ActivityLog/Listeners/Orders/LogRefundListener.php
@@ -11,14 +11,14 @@ class LogRefundListener
     /**
      * The current requst.
      *
-     * @var Request
+     * @var \Illuminate\Http\Request
      */
     protected $request;
 
     /**
      * The log factory.
      *
-     * @var ActivityLogFactoryInterface
+     * @var \GetCandy\Api\Core\ActivityLog\Interfaces\ActivityLogFactoryInterface
      */
     protected $factory;
 
@@ -31,7 +31,7 @@ class LogRefundListener
     /**
      * Handle the event.
      *
-     * @param  OrderRefundEvent  $event
+     * @param  \GetCandy\Api\Core\Orders\Events\OrderRefundEvent  $event
      * @return void
      */
     public function handle(OrderRefundEvent $event)

--- a/src/Core/Addresses/Models/Address.php
+++ b/src/Core/Addresses/Models/Address.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Address extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'user';
 
     /**

--- a/src/Core/Addresses/Services/AddressService.php
+++ b/src/Core/Addresses/Services/AddressService.php
@@ -7,6 +7,9 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 
 class AddressService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Addresses\Models\Address
+     */
     protected $model;
 
     public function __construct()
@@ -17,10 +20,9 @@ class AddressService extends BaseService
     /**
      * Checks whether an address already exists.
      *
-     * @param string $user
-     * @param array $details
-     * @param string $type
-     *
+     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  array  $details
+     * @param  string  $type
      * @return bool
      */
     public function exists($user, array $details, $type = 'billing')
@@ -45,10 +47,9 @@ class AddressService extends BaseService
     /**
      * Create a new address.
      *
-     * @param User $user
-     * @param array $data
-     *
-     * @return Address
+     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  array $data
+     * @return \GetCandy\Api\Core\Addresses\Models\Address
      */
     public function create($user, array $data)
     {
@@ -77,8 +78,8 @@ class AddressService extends BaseService
     }
 
     /**
-     * @param string $hashedAddressId
-     * @return Address
+     * @param  string  $hashedAddressId
+     * @return \GetCandy\Api\Core\Addresses\Models\Address
      */
     public function makeDefault(string $hashedAddressId): Address
     {
@@ -93,8 +94,8 @@ class AddressService extends BaseService
     }
 
     /**
-     * @param string $hashedAddressId
-     * @return Address
+     * @param  string  $hashedAddressId
+     * @return \GetCandy\Api\Core\Addresses\Models\Address
      */
     public function removeDefault(string $hashedAddressId): Address
     {
@@ -107,8 +108,9 @@ class AddressService extends BaseService
     }
 
     /**
-     * @param int $userId
-     * @param string $type - 'billing' or 'shipping'
+     * @param  int  $userId
+     * @param  string  $type - 'billing' or 'shipping'
+     * @return void
      */
     private function removeAllDefaultForType(int $userId, string $type)
     {

--- a/src/Core/Assets/Drivers/BaseUploadDriver.php
+++ b/src/Core/Assets/Drivers/BaseUploadDriver.php
@@ -16,8 +16,7 @@ abstract class BaseUploadDriver
     /**
      * Get the video unique id.
      *
-     * @param string $url
-     *
+     * @param  string  $url
      * @return string
      */
     public function getUniqueId($url)
@@ -26,9 +25,8 @@ abstract class BaseUploadDriver
     }
 
     /**
-     * @param array $data
-     * @param       $source
-     *
+     * @param  array  $data
+     * @param  mixed  $source
      * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function prepare(array $data, $source)
@@ -80,9 +78,8 @@ abstract class BaseUploadDriver
     }
 
     /**
-     * @param array $data
-     * @param       $model
-     *
+     * @param  array  $data
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function process(array $data, $model)

--- a/src/Core/Assets/Drivers/BaseUrlDriver.php
+++ b/src/Core/Assets/Drivers/BaseUrlDriver.php
@@ -18,7 +18,7 @@ abstract class BaseUrlDriver
     protected $upload = true;
 
     /**
-     * @var string
+     * @var null|string
      */
     protected $hashedName = null;
 
@@ -28,12 +28,12 @@ abstract class BaseUrlDriver
     protected $info;
 
     /**
-     * @var GetCandy\Api\Core\Assets\Models\AssetSource
+     * @var \GetCandy\Api\Core\Assets\Models\AssetSource
      */
     protected $source;
 
     /**
-     * @var Illuminate\Database\Eloquent\Model
+     * @var \Illuminate\Database\Eloquent\Model
      */
     protected $model;
 
@@ -43,9 +43,8 @@ abstract class BaseUrlDriver
     protected $data;
 
     /**
-     * @param array $data
-     * @param       $model
-     *
+     * @param  array  $data
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function process(array $data, Model $model = null)
@@ -85,9 +84,10 @@ abstract class BaseUrlDriver
 
     /**
      * Prepares the asset.
-     * @param  array $data
-     * @param  Model $model
-     * @return Asset
+     * 
+     * @param  array  $data
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     protected function prepare()
     {
@@ -104,6 +104,8 @@ abstract class BaseUrlDriver
 
     /**
      * Generates a hashed name.
+     * 
+     * @return string
      */
     public function hashName()
     {
@@ -112,8 +114,8 @@ abstract class BaseUrlDriver
 
     /**
      * Get the thumbnail for the video.
-     * @param  string $url
-     * @return Intervention\Image
+     * 
+     * @return null|\Intervention\Image\Image
      */
     public function getThumbnail()
     {
@@ -124,8 +126,9 @@ abstract class BaseUrlDriver
 
     /**
      * Gets an image from a given url.
-     * @param  string $url
-     * @return Intervention\Image
+     * 
+     * @param  string  $url
+     * @return null|Intervention\Image\Image
      */
     public function getImageFromUrl($url)
     {
@@ -141,8 +144,7 @@ abstract class BaseUrlDriver
     /**
      * Get the OEM data.
      *
-     * @param array $params
-     *
+     * @param  array  $params
      * @return mixed
      */
     protected function getOemData($params = [])

--- a/src/Core/Assets/Drivers/ExternalImage.php
+++ b/src/Core/Assets/Drivers/ExternalImage.php
@@ -11,7 +11,7 @@ use Storage;
 class ExternalImage extends BaseUrlDriver
 {
     /**
-     * @var InterventionImage
+     * @var \Intervention\Image\ImageManager
      */
     protected $manager;
 
@@ -28,10 +28,9 @@ class ExternalImage extends BaseUrlDriver
     /**
      * Process the external image.
      *
-     * @param array $data
-     * @param Model $model
-     *
-     * @return Asset
+     * @param  array $data
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function process(array $data, Model $model)
     {
@@ -81,9 +80,6 @@ class ExternalImage extends BaseUrlDriver
     }
 
     /**
-     * @param array $data
-     * @param       $source
-     *
      * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function prepare()
@@ -114,8 +110,7 @@ class ExternalImage extends BaseUrlDriver
     /**
      * Get the asset info.
      *
-     * @param string $url
-     *
+     * @param  string  $url
      * @return array
      */
     public function getInfo($url)

--- a/src/Core/Assets/Drivers/Image.php
+++ b/src/Core/Assets/Drivers/Image.php
@@ -12,9 +12,8 @@ use Symfony\Component\Finder\SplFileInfo;
 class Image extends BaseUploadDriver implements AssetDriverContract
 {
     /**
-     * @param array $data
-     * @param       $model
-     *
+     * @param  array  $data
+     * @param  null|\Illuminate\Database\Eloquent\Model  $model
      * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function process(array $data, $model = null)

--- a/src/Core/Assets/Drivers/Vimeo.php
+++ b/src/Core/Assets/Drivers/Vimeo.php
@@ -7,7 +7,7 @@ use Vimeo\Laravel\VimeoManager;
 class Vimeo extends BaseUrlDriver
 {
     /**
-     * @var Vinkla\Vimeo\VimeoManager
+     * @var \Vinkla\Vimeo\VimeoManager
      */
     protected $manager;
 
@@ -29,8 +29,7 @@ class Vimeo extends BaseUrlDriver
     /**
      * Get the vimeo video info.
      *
-     * @param string $url
-     *
+     * @param  string  $url
      * @return array
      */
     public function getInfo($url)

--- a/src/Core/Assets/Drivers/YouTube.php
+++ b/src/Core/Assets/Drivers/YouTube.php
@@ -5,7 +5,7 @@ namespace GetCandy\Api\Core\Assets\Drivers;
 class YouTube extends BaseUrlDriver
 {
     /**
-     * @var Alaouy\Youtube\Youtube
+     * @var \Alaouy\Youtube\Youtube
      */
     protected $manager;
 
@@ -27,8 +27,7 @@ class YouTube extends BaseUrlDriver
     /**
      * Get the video unique id.
      *
-     * @param string $url
-     *
+     * @param  string  $url
      * @return string
      */
     public function getUniqueId($url)
@@ -39,8 +38,7 @@ class YouTube extends BaseUrlDriver
     /**
      * Get the video info.
      *
-     * @param string $url
-     *
+     * @param  string  $url
      * @return array
      */
     public function getInfo($url)

--- a/src/Core/Assets/Jobs/CleanUpAssetFiles.php
+++ b/src/Core/Assets/Jobs/CleanUpAssetFiles.php
@@ -14,13 +14,14 @@ class CleanUpAssetFiles implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
-     * @var \GetCandy\Api\Core\Assets\Models\Asset
+     * @var \Illuminate\Support\Collection
      */
     protected $assets;
 
     /**
      * Create a new job instance.
      *
+     * @param  \GetCandy\Api\Core\Assets\Models\Asset[]  $assets
      * @return void
      */
     public function __construct($assets)

--- a/src/Core/Assets/Jobs/GenerateTransforms.php
+++ b/src/Core/Assets/Jobs/GenerateTransforms.php
@@ -13,15 +13,20 @@ class GenerateTransforms implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
-     * @var \GetCandy\Api\Core\Assets\Models\Asset
+     * @var \Illuminate\Support\Collection
      */
     protected $assets;
 
+    /**
+     * @var null|array
+     */
     protected $settings;
 
     /**
      * Create a new job instance.
      *
+     * @param  \GetCandy\Api\Core\Assets\Models\Asset[]  $assets
+     * @param  null|array  $settings
      * @return void
      */
     public function __construct($assets, $settings = null)

--- a/src/Core/Assets/Models/Asset.php
+++ b/src/Core/Assets/Models/Asset.php
@@ -8,6 +8,11 @@ use Storage;
 
 class Asset extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     /**
@@ -66,7 +71,7 @@ class Asset extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function transforms()
     {

--- a/src/Core/Assets/Models/AssetSource.php
+++ b/src/Core/Assets/Models/AssetSource.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class AssetSource extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'assets';
 
     /**

--- a/src/Core/Assets/Models/AssetTransform.php
+++ b/src/Core/Assets/Models/AssetTransform.php
@@ -7,6 +7,11 @@ use Storage;
 
 class AssetTransform extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     protected $table = 'asset_transforms';

--- a/src/Core/Assets/Models/Transform.php
+++ b/src/Core/Assets/Models/Transform.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Transform extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'assets';
 
     /**

--- a/src/Core/Assets/Services/AssetService.php
+++ b/src/Core/Assets/Services/AssetService.php
@@ -17,10 +17,10 @@ class AssetService extends BaseService
 
     /**
      * Gets the driver for the upload.
-     * @param  string $mimeType
+     * 
+     * @param  string  $mimeType
      * @return mixed
-     *
-     **/
+     */
     public function getDriver($mimeType)
     {
         $kind = explode('/', $mimeType);
@@ -30,10 +30,11 @@ class AssetService extends BaseService
 
     /**
      * Uploads an asset.
+     * 
      * @param  array  $data
-     * @param  Model   $model
-     * @param  int $position
-     * @return Asset
+     * @param  null|\Illuminate\Database\Eloquent\Model  $model
+     * @param  int  $position
+     * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function upload($data, Model $model = null, $position = 0)
     {
@@ -64,9 +65,8 @@ class AssetService extends BaseService
     /**
      * Update all the assets.
      *
-     * @param array $assets
-     *
-     * @return void
+     * @param  array  $assets
+     * @return bool
      */
     public function updateAll($assets)
     {
@@ -85,10 +85,9 @@ class AssetService extends BaseService
     /**
      * Update an asset.
      *
-     * @param string $id
-     * @param array $data
-     *
-     * @return Asset
+     * @param  string  $id
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Assets\Models\Asset
      */
     public function update($id, array $data)
     {
@@ -102,10 +101,9 @@ class AssetService extends BaseService
     /**
      * Get some assets.
      *
-     * @param Model $assetable
-     * @param array $params
-     *
-     * @return Collection
+     * @param  \Illuminate\Database\Eloquent\Model  $assetable
+     * @param  array  $params
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getAssets(Model $assetable, $params = [])
     {
@@ -124,8 +122,9 @@ class AssetService extends BaseService
     /**
      * Detach an asset.
      *
-     * @param string $assetId
-     *
+     * @param  string  $assetId
+     * @param  mixed  $ownerId
+     * @param  mixed  $ownerType
      * @return bool
      */
     public function detach($assetId, $ownerId, $ownerType)
@@ -143,8 +142,7 @@ class AssetService extends BaseService
     /**
      * Delete an asset.
      *
-     * @param string $id
-     *
+     * @param  string  $id
      * @return bool
      */
     public function delete($id)

--- a/src/Core/Assets/Services/AssetTransformService.php
+++ b/src/Core/Assets/Services/AssetTransformService.php
@@ -20,9 +20,8 @@ class AssetTransformService extends BaseService
     }
 
     /**
-     * @param $handle
-     *
-     * @return mixed
+     * @param  string  $handle
+     * @return null|\Illuminate\Database\Eloquent\Model
      */
     public function getByHandle($handle)
     {
@@ -30,8 +29,7 @@ class AssetTransformService extends BaseService
     }
 
     /**
-     * @param array $handles
-     *
+     * @param  array  $handles
      * @return \Illuminate\Database\Eloquent\Collection|static[]
      */
     public function getByHandles(array $handles)
@@ -40,9 +38,8 @@ class AssetTransformService extends BaseService
     }
 
     /**
-     * @param $transformer
-     * @param $asset
-     *
+     * @param  \GetCandy\Api\Core\Assets\Models\Transform  $transformer
+     * @param  \GetCandy\Api\Core\Assets\Models\Asset  $asset
      * @return bool
      */
     protected function process($transformer, $asset)
@@ -108,8 +105,9 @@ class AssetTransformService extends BaseService
     }
 
     /**
-     * @param                                   $ref
-     * @param \GetCandy\Api\Core\Assets\Models\Asset $asset
+     * @param  mixed  $ref
+     * @param  \GetCandy\Api\Core\Assets\Models\Asset  $asset
+     * @return void
      */
     public function transform($ref, Asset $asset)
     {
@@ -131,8 +129,8 @@ class AssetTransformService extends BaseService
     /**
      * Get the image.
      *
-     * @param [type] $asset
-     * @return void
+     * @param  \GetCandy\Api\Core\Assets\Models\Asset  $asset
+     * @return bool|\Intervention\Image\Image
      */
     protected function getImage($asset)
     {

--- a/src/Core/Associations/Models/AssociationGroup.php
+++ b/src/Core/Associations/Models/AssociationGroup.php
@@ -7,9 +7,16 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 class AssociationGroup extends BaseModel
 {
     /**
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'main';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = ['association_id', 'type'];
 }

--- a/src/Core/Attributes/Events/AttributableSavedEvent.php
+++ b/src/Core/Attributes/Events/AttributableSavedEvent.php
@@ -6,12 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class AttributableSavedEvent
 {
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
     public $model;
 
     /**
      * Create a new event instance.
      *
-     * @param  Order  $order
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
     public function __construct(Model $model)

--- a/src/Core/Attributes/Events/AttributeSavedEvent.php
+++ b/src/Core/Attributes/Events/AttributeSavedEvent.php
@@ -27,7 +27,7 @@ class AttributeSavedEvent implements ShouldBroadcast
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return array
+     * @return \Illuminate\Broadcasting\Channel
      */
     public function broadcastOn()
     {

--- a/src/Core/Attributes/Listeners/SyncAttributablesListener.php
+++ b/src/Core/Attributes/Listeners/SyncAttributablesListener.php
@@ -9,7 +9,7 @@ class SyncAttributablesListener
     /**
      * Handle the event.
      *
-     * @param  OrderShipped  $event
+     * @param  \GetCandy\Api\Core\Attributes\Events\AttributableSavedEvent  $event
      * @return void
      */
     public function handle(AttributableSavedEvent $event)

--- a/src/Core/Attributes/Models/Attribute.php
+++ b/src/Core/Attributes/Models/Attribute.php
@@ -9,6 +9,11 @@ class Attribute extends BaseModel
 {
     use HasTranslations;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'attribute';
 
     /**
@@ -43,7 +48,9 @@ class Attribute extends BaseModel
 
     /**
      * Sets the name attribute to a json string.
-     * @param array $value
+     * 
+     * @param  array  $value
+     * @return void
      */
     public function setLookupsAttribute($value)
     {

--- a/src/Core/Attributes/Models/AttributeGroup.php
+++ b/src/Core/Attributes/Models/AttributeGroup.php
@@ -9,6 +9,11 @@ class AttributeGroup extends BaseModel
 {
     use HasTranslations;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'attribute_group';
 
     /**
@@ -23,7 +28,8 @@ class AttributeGroup extends BaseModel
 
     /**
      * Get the attributes associated to the group.
-     * @return Illuminate\Database\Eloquent\Relations\HasMany
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function attributes()
     {

--- a/src/Core/Attributes/Services/AttributeGroupService.php
+++ b/src/Core/Attributes/Services/AttributeGroupService.php
@@ -9,7 +9,7 @@ use GetCandy\Api\Exceptions\DuplicateValueException;
 class AttributeGroupService extends BaseService
 {
     /**
-     * @var AttributeGroup
+     * @var \GetCandy\Api\Core\Attributes\Models\AttributeGroup
      */
     protected $model;
 
@@ -22,8 +22,8 @@ class AttributeGroupService extends BaseService
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return AttributeGroup
+     * @param  null|array|string  $includes
+     * @return \GetCandy\Api\Core\Attributes\Models\AttributeGroup
      */
     public function create(array $data, $includes = null)
     {
@@ -53,9 +53,12 @@ class AttributeGroupService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     * 
+     * @param  string  $id
+     * @param  null|array|string  $includes
+     * @return \GetCandy\Api\Core\Attributes\Models\AttributeGroup
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id, $includes = null)
     {
@@ -73,13 +76,12 @@ class AttributeGroupService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $id
+     * @param  string  $id
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Attributes\Models\AttributeGroup
      *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
-     *
-     * @return GetCandy\Api\Core\Models\AttributeGroup
      */
     public function update($hashedId, array $data)
     {
@@ -100,12 +102,12 @@ class AttributeGroupService extends BaseService
 
     /**
      * Updates the positions of attribute groups.
+     * 
      * @param  array  $data
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\HttpException
-     * @throws GetCandy\Api\Core\Exceptions\DuplicateValueException
-     *
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     * @throws \GetCandy\Api\Exceptions\DuplicateValueException
      */
     public function updateGroupPositions(array $data)
     {
@@ -137,12 +139,13 @@ class AttributeGroupService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws Symfony\Component\HttpKernel\Exception\HttpException
-     *
+     * @param  string  $id
+     * @param  string  $adopterId
+     * @param  bool  $deleteAttributes
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function delete($id, $adopterId = null, $deleteAttributes = false)
     {

--- a/src/Core/Attributes/Services/AttributeService.php
+++ b/src/Core/Attributes/Services/AttributeService.php
@@ -10,7 +10,7 @@ use GetCandy\Api\Exceptions\DuplicateValueException;
 class AttributeService extends BaseService
 {
     /**
-     * @var AttributeGroup
+     * @var \GetCandy\Api\Core\Attributes\Models\Attribute
      */
     protected $model;
 
@@ -23,8 +23,7 @@ class AttributeService extends BaseService
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return GetCandy\Api\Core\Models\Attribute
+     * @return \GetCandy\Api\Core\Attributes\Models\Attribute
      */
     public function create(array $data)
     {
@@ -79,12 +78,12 @@ class AttributeService extends BaseService
 
     /**
      * Updates the positions of attributes.
+     * 
      * @param  array  $data
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\HttpException
-     * @throws GetCandy\Api\Core\Exceptions\DuplicateValueException
-     *
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     * @throws \GetCandy\Api\Exceptions\DuplicateValueException
      */
     public function updateAttributePositions(array $data)
     {
@@ -117,12 +116,11 @@ class AttributeService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $id
+     * @param  string  $hashedId
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Attributes\Models\Attribute
      *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
-     * @return GetCandy\Api\Core\Models\Attribute
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function update($hashedId, array $data)
     {
@@ -148,11 +146,10 @@ class AttributeService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
+     * @param  string  $id
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function delete($id)
     {
@@ -180,8 +177,9 @@ class AttributeService extends BaseService
 
     /**
      * Returns attributes for a group.
-     * @param  string $groupId
-     * @return Collection
+     * 
+     * @param  string  $groupId
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getAttributesForGroup($groupId)
     {
@@ -208,9 +206,10 @@ class AttributeService extends BaseService
     }
 
     /**
-     * Gets the last attribute for a groupo.
-     * @param  string $groupId
-     * @return null|Attribute
+     * Gets the last attribute for a group.
+     * 
+     * @param  string  $groupId
+     * @return null|\GetCandy\Api\Core\Attributes\Models\Attribute
      */
     public function getLastItem($groupId)
     {
@@ -219,9 +218,10 @@ class AttributeService extends BaseService
 
     /**
      * Checks whether a attribute name exists in a group.
-     * @param  string $value
-     * @param  string $groupId
-     * @param  string $attributeId
+     * 
+     * @param  string  $value
+     * @param  string  $groupId
+     * @param  null|string  $attributeId
      * @return bool
      */
     public function nameExistsInGroup($value, $groupId, $attributeId = null)

--- a/src/Core/Auth/Models/User.php
+++ b/src/Core/Auth/Models/User.php
@@ -21,6 +21,11 @@ class User extends Authenticatable
         Hashids,
         HasRoles;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'user';
 
     protected $guard_name = 'api';
@@ -63,8 +68,8 @@ class User extends Authenticatable
     ];
 
     /**
-     * @param Builder $qb
-     * @return Builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $qb
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeDefault($qb)
     {

--- a/src/Core/Auth/Services/UserService.php
+++ b/src/Core/Auth/Services/UserService.php
@@ -24,9 +24,12 @@ class UserService extends BaseService
 
     /**
      * Gets paginated data for the record.
-     * @param  int $length How many results per page
-     * @param  int  $page   The page to start
-     * @return Illuminate\Pagination\LengthAwarePaginator
+     * 
+     * @param  int  $length
+     * @param  null|int  $page
+     * @param  null|string $keywords
+     * @param  array  $ids
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getPaginatedData($length = 50, $page = null, $keywords = null, $ids = [])
     {
@@ -115,8 +118,7 @@ class UserService extends BaseService
     /**
      * Creates a user token.
      *
-     * @param string $userId
-     *
+     * @param  string  $userId
      * @return PersonalAccessTokenResult
      */
     public function getImpersonationToken($userId)

--- a/src/Core/Baskets/Events/BasketFetchedEvent.php
+++ b/src/Core/Baskets/Events/BasketFetchedEvent.php
@@ -13,11 +13,15 @@ class BasketFetchedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @var \GetCandy\Api\Core\Baskets\Models\Basket
+     */
     public $basket;
 
     /**
      * Create a new event instance.
      *
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
      * @return void
      */
     public function __construct(Basket $basket)
@@ -28,7 +32,7 @@ class BasketFetchedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Baskets/Events/BasketStoredEvent.php
+++ b/src/Core/Baskets/Events/BasketStoredEvent.php
@@ -13,11 +13,15 @@ class BasketStoredEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @var \GetCandy\Api\Core\Baskets\Models\Basket
+     */
     public $basket;
 
     /**
      * Create a new event instance.
      *
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
      * @return void
      */
     public function __construct(Basket $basket)
@@ -28,7 +32,7 @@ class BasketStoredEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Baskets/Factories/BasketDiscountFactory.php
+++ b/src/Core/Baskets/Factories/BasketDiscountFactory.php
@@ -21,8 +21,8 @@ class BasketDiscountFactory implements BasketDiscountFactoryInterface
     /**
      * Add a discount to the pool.
      *
-     * @param string $discount
-     * @return void
+     * @param  string  $discount
+     * @return $this
      */
     public function add($discount)
     {

--- a/src/Core/Baskets/Factories/BasketFactory.php
+++ b/src/Core/Baskets/Factories/BasketFactory.php
@@ -14,24 +14,27 @@ class BasketFactory implements BasketFactoryInterface
     /**
      * The current basket.
      *
-     * @var Basket
+     * @var \GetCandy\Api\Core\Baskets\Models\Basket
      */
     protected $basket;
 
     /**
      * The order attached to the basket.
      *
-     * @var Order
+     * @var \GetCandy\Api\Core\Orders\Models\Order
      */
     protected $order;
 
     /**
      * The basket lines.
      *
-     * @var BasketLineInterface
+     * @var \GetCandy\Api\Core\Baskets\Interfaces\BasketLineInterface
      */
     public $lines;
 
+    /**
+     * @var \GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface
+     */
     protected $tax;
 
     /**
@@ -52,8 +55,8 @@ class BasketFactory implements BasketFactoryInterface
     /**
      * Initialise with the basket.
      *
-     * @param Basket $basket
-     * @return BasketFactory
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @return $this
      */
     public function init(Basket $basket)
     {
@@ -79,8 +82,8 @@ class BasketFactory implements BasketFactoryInterface
     /**
      * Whether the basket has been changed.
      *
-     * @param bool $bool
-     * @return self
+     * @param  bool  $bool
+     * @return $this
      */
     public function changed($bool)
     {
@@ -92,7 +95,7 @@ class BasketFactory implements BasketFactoryInterface
     /**
      * Set the basket totals.
      *
-     * @return BasketFactory
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function get()
     {
@@ -128,7 +131,7 @@ class BasketFactory implements BasketFactoryInterface
     /**
      * Clone the basket.
      *
-     * @return Basket
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function clone()
     {

--- a/src/Core/Baskets/Factories/BasketLineFactory.php
+++ b/src/Core/Baskets/Factories/BasketLineFactory.php
@@ -13,28 +13,28 @@ class BasketLineFactory implements BasketLineInterface
     /**
      * The basket lines.
      *
-     * @var Collection
+     * @var \Illuminate\Support\Collection
      */
     public $lines;
 
     /**
      * The variant factory.
      *
-     * @var ProductVariantInterface
+     * @var \GetCandy\Api\Core\Products\Interfaces\ProductVariantInterface
      */
     protected $variantFactory;
 
     /**
      * The discount factory.
      *
-     * @var DiscountFactoryInterface
+     * @var \GetCandy\Api\Core\Baskets\Interfaces\BasketDiscountFactoryInterface
      */
     protected $discounts;
 
     /**
      * The tax calculator instance.
      *
-     * @var TaxCalculatorInterface
+     * @var \GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface
      */
     protected $tax;
 
@@ -52,8 +52,8 @@ class BasketLineFactory implements BasketLineInterface
     /**
      * Add lines to the instance.
      *
-     * @param Collection $lines
-     * @return void
+     * @param  \Illuminate\Support\Collection  $lines
+     * @return $this
      */
     public function add($lines)
     {
@@ -65,8 +65,8 @@ class BasketLineFactory implements BasketLineInterface
     /**
      * Initialise the factory.
      *
-     * @param BasketLine $line
-     * @return BasketLineFactory
+     * @param  \GetCandy\Api\Core\Baskets\Models\BasketLine  $line
+     * @return $this
      */
     public function init(BasketLine $line)
     {
@@ -78,8 +78,8 @@ class BasketLineFactory implements BasketLineInterface
     /**
      * Add a discount to the instance.
      *
-     * @param string $coupon
-     * @return self
+     * @param  string  $coupon
+     * @return $this
      */
     public function discount($coupon)
     {
@@ -91,7 +91,7 @@ class BasketLineFactory implements BasketLineInterface
     /**
      * Get the basket line.
      *
-     * @return BasketLine
+     * @return \GetCandy\Api\Core\Baskets\Models\BasketLine
      */
     public function get()
     {

--- a/src/Core/Baskets/Models/Basket.php
+++ b/src/Core/Baskets/Models/Basket.php
@@ -13,6 +13,11 @@ class Basket extends BaseModel
 {
     use HasCompletion, HasMeta;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'basket';
 
     /**
@@ -58,7 +63,7 @@ class Basket extends BaseModel
     public $hasExclusions = false;
 
     /**
-     * The fillable attributes.
+     * The attributes that are mass assignable.
      *
      * @var array
      */
@@ -69,7 +74,7 @@ class Basket extends BaseModel
     /**
      * Get the basket lines.
      *
-     * @return void
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function lines()
     {
@@ -94,7 +99,7 @@ class Basket extends BaseModel
     /**
      * Get the basket user.
      *
-     * @return User
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user()
     {
@@ -119,7 +124,7 @@ class Basket extends BaseModel
     /**
      * Get the saved basket relation.
      *
-     * @return HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function savedBasket()
     {

--- a/src/Core/Baskets/Models/BasketLine.php
+++ b/src/Core/Baskets/Models/BasketLine.php
@@ -10,6 +10,11 @@ class BasketLine extends BaseModel
 {
     use HasMeta;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'basket';
 
     public $total_cost;
@@ -20,6 +25,11 @@ class BasketLine extends BaseModel
     public $base_cost;
     public $discount_total;
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = ['quantity', 'product_variant_id', 'total', 'meta'];
 
     public function variant()

--- a/src/Core/Baskets/Models/SavedBasket.php
+++ b/src/Core/Baskets/Models/SavedBasket.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class SavedBasket extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public function basket()

--- a/src/Core/Baskets/Services/BasketLineService.php
+++ b/src/Core/Baskets/Services/BasketLineService.php
@@ -10,19 +10,19 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 class BasketLineService extends BaseService
 {
     /**
-     * @var Basket
+     * @var \GetCandy\Api\Core\Baskets\Models\BasketLine
      */
     protected $model;
 
     /**
      * The basket factory.
      *
-     * @var BasketFactoryInterface
+     * @var \GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface
      */
     protected $factory;
 
     /**
-     * @var string
+     * @var array
      */
     protected $includes = [];
 
@@ -33,7 +33,8 @@ class BasketLineService extends BaseService
     }
 
     /**
-     * @param null|string $includes
+     * @param  null|string  $includes
+     * @return void
      */
     public function setIncludes(?string $includes)
     {
@@ -41,9 +42,9 @@ class BasketLineService extends BaseService
     }
 
     /**
-     * @param $id
-     * @param $variant
-     * @return mixed
+     * @param  string  $id
+     * @param  string  $variant
+     * @return bool
      */
     public function variantExists($id, $variant)
     {
@@ -57,9 +58,9 @@ class BasketLineService extends BaseService
     }
 
     /**
-     * @param string $id
-     * @param int $quantity
-     * @return Basket
+     * @param  string  $id
+     * @param  int  $quantity
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function setQuantity(string $id, int $quantity)
     {
@@ -76,10 +77,9 @@ class BasketLineService extends BaseService
     }
 
     /**
-     * @param string $id
-     * @param int $quantity
-     * @param array $includes
-     * @return Basket
+     * @param  string  $id
+     * @param  int  $quantity
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function changeQuantity(string $id, int $quantity)
     {
@@ -96,8 +96,8 @@ class BasketLineService extends BaseService
     }
 
     /**
-     * @param array $lines
-     * @return Basket
+     * @param  array  $lines
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function destroy(array $lines)
     {
@@ -121,8 +121,8 @@ class BasketLineService extends BaseService
     }
 
     /**
-     * @param BasketLine $basketLine
-     * @param int $quantity
+     * @param  \GetCandy\Api\Core\Baskets\Models\BasketLine  $basketLine
+     * @param  int  $quantity
      * @return bool
      */
     protected function saveQuantity(BasketLine $basketLine, int $quantity)

--- a/src/Core/Baskets/Services/BasketService.php
+++ b/src/Core/Baskets/Services/BasketService.php
@@ -17,21 +17,21 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 class BasketService extends BaseService
 {
     /**
-     * @var Basket
+     * @var \GetCandy\Api\Core\Baskets\Models\Basket
      */
     protected $model;
 
     /**
      * The basket factory.
      *
-     * @var BasketFactoryInterface
+     * @var \GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface
      */
     protected $factory;
 
     /**
      * The variant factory.
      *
-     * @var ProductVariantInterface
+     * @var \GetCandy\Api\Core\Products\Interfaces\ProductVariantInterface
      */
     protected $variantFactory;
 
@@ -47,10 +47,9 @@ class BasketService extends BaseService
     /**
      * Gets either a new or existing basket for a user.
      *
-     * @param mixed $id
-     * @param mixed $user
-     *
-     * @return Basket
+     * @param  null|string  $id
+     * @param  null|\Illuminate\Database\Eloquent\Model  $user
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function getBasket($id = null, $user = null)
     {
@@ -77,8 +76,8 @@ class BasketService extends BaseService
     /**
      * Get a basket by it's hashed ID.
      *
-     * @param string $id
-     * @return BasketFactory
+     * @param  string  $id
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function getByHashedId($id)
     {
@@ -105,8 +104,8 @@ class BasketService extends BaseService
     /**
      * Get basket for an order.
      *
-     * @param Order $order
-     * @return Basket
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function getForOrder(Order $order)
     {
@@ -120,9 +119,8 @@ class BasketService extends BaseService
     /**
      * Detach a user from a basket.
      *
-     * @param string $basketId
-     *
-     * @return Basket
+     * @param  string  $basketId
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function removeUser($basketId)
     {
@@ -152,10 +150,9 @@ class BasketService extends BaseService
     /**
      * Add a user to a basket.
      *
-     * @param string $basketId
-     * @param string $userId
-     *
-     * @return Basket
+     * @param  string  $basketId
+     * @param  string  $userId
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function addUser($basketId, $userId)
     {
@@ -170,10 +167,9 @@ class BasketService extends BaseService
     /**
      * Store a basket.
      *
-     * @param array $data
-     * @param ?User $user
-     *
-     * @return Basket
+     * @param  array  $data
+     * @param  null|\Illuminate\Database\Eloquent\Model  $user
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function store(array $data, $user = null)
     {
@@ -192,10 +188,9 @@ class BasketService extends BaseService
     /**
      * Add new lines to a basket, without remapping the existing lines.
      *
-     * @param array $data
-     * @param ?User $user
-     *
-     * @return Basket
+     * @param  array  $data
+     * @param  null|\Illuminate\Database\Eloquent\Model  $user
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function addLines(array $data, $user = null)
     {
@@ -210,9 +205,9 @@ class BasketService extends BaseService
     }
 
     /**
-     * @param Basket $basket
-     * @param array $data
-     * @return Basket
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     protected function setupBasket(Basket $basket, array $data)
     {
@@ -231,9 +226,9 @@ class BasketService extends BaseService
     }
 
     /**
-     * @param Basket $basket
-     * @param array  $data
-     * @return Basket
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     protected function storeAndUpdateBasket(Basket $basket, array $data)
     {
@@ -272,10 +267,9 @@ class BasketService extends BaseService
     /**
      * Saves a basket with a name.
      *
-     * @param string $basketId
-     * @param string $name
-     *
-     * @return Basket
+     * @param  string  $basketId
+     * @param  string  $name
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function save($basketId, $name)
     {
@@ -298,8 +292,8 @@ class BasketService extends BaseService
     /**
      * Get a users saved baskets.
      *
-     * @param mixed $user
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getSaved($user)
     {
@@ -350,10 +344,9 @@ class BasketService extends BaseService
     /**
      * Adds a discount to a basket.
      *
-     * @param string $basketId
-     * @param string $coupon
-     *
-     * @return Basket
+     * @param  string  $basketId
+     * @param  string  $coupon
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function addDiscount($basketId, $coupon)
     {
@@ -370,9 +363,9 @@ class BasketService extends BaseService
     /**
      * Delete a discount.
      *
-     * @param string $basketId
-     * @param string $discountId
-     * @return void
+     * @param  string  $basketId
+     * @param  string  $discountId
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function deleteDiscount($basketId, $discountId)
     {
@@ -404,9 +397,9 @@ class BasketService extends BaseService
     /**
      * Get a basket for a user.
      *
-     * @param mixed $user
-     *
-     * @return mixed
+     * @param  string|\Illuminate\Database\Eloquent\Model  $user
+     * @param  array  $includes
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function getCurrentForUser($user, $includes = [])
     {
@@ -434,11 +427,10 @@ class BasketService extends BaseService
     /**
      * Resolves a guest basket with an existing basket.
      *
-     * @param User $user
-     * @param string $basketId
-     * @param bool $merge
-     *
-     * @return Basket
+     * @param  \Illuminate\Database\Eloquent\Model $user
+     * @param  string  $basketId
+     * @param  bool  $merge
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function resolve($user, $basketId, $merge = true)
     {
@@ -463,9 +455,9 @@ class BasketService extends BaseService
     /**
      * Merges two baskets.
      *
-     * @param Basket $guestBasket
-     * @param Basket $userBasket
-     * @return Basket
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $guestBasket
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $userBasket
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function merge($guestBasket, $userBasket)
     {
@@ -503,7 +495,7 @@ class BasketService extends BaseService
     /**
      * Delete a basket.
      *
-     * @param mixed $basket
+     * @param  string|\GetCandy\Api\Core\Baskets\Models\Basket  $basket
      * @return bool
      */
     public function destroy($basket)

--- a/src/Core/Baskets/Services/SavedBasketService.php
+++ b/src/Core/Baskets/Services/SavedBasketService.php
@@ -8,6 +8,9 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 
 class SavedBasketService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Baskets\Models\SavedBasket
+     */
     protected $model;
 
     public function __construct()
@@ -18,9 +21,9 @@ class SavedBasketService extends BaseService
     /**
      * Update a saved basket.
      *
-     * @param string $id
-     * @param array $payload
-     * @return void
+     * @param  string  $hashedId
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Baskets\Models\SavedBasket
      */
     public function update($hashedId, array $data)
     {

--- a/src/Core/Categories/Drafting/CategoryDrafter.php
+++ b/src/Core/Categories/Drafting/CategoryDrafter.php
@@ -65,10 +65,8 @@ class CategoryDrafter extends BaseDrafter implements DrafterInterface
     }
 
     /**
-     * Duplicate a product.
-     *
-     * @param Collection $data
-     * @return Product
+     * @param  \Illuminate\Database\Eloquent\Model  $category
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function firstOrCreate(Model $category)
     {

--- a/src/Core/Categories/Events/CategoryStoredEvent.php
+++ b/src/Core/Categories/Events/CategoryStoredEvent.php
@@ -13,11 +13,15 @@ class CategoryStoredEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @var \GetCandy\Api\Core\Categories\Models\Category
+     */
     protected $category;
 
     /**
      * Create a new event instance.
      *
+     * @param  \GetCandy\Api\Core\Categories\Models\Category  $category
      * @return void
      */
     public function __construct(Category $category)
@@ -33,7 +37,7 @@ class CategoryStoredEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Categories/Models/Category.php
+++ b/src/Core/Categories/Models/Category.php
@@ -28,10 +28,23 @@ class Category extends BaseModel
         Draftable,
         Versionable;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
+    /**
+     * @var string
+     */
     protected $settings = 'categories';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */    
     protected $fillable = [
         'attribute_data', 'parent_id',
     ];
@@ -74,9 +87,8 @@ class Category extends BaseModel
     }
 
     /**
-     * @param string $table
-     *
-     * @return QueryBuilder
+     * @param  null|string $table
+     * @return \GetCandy\Api\Core\Categories\QueryBuilder
      */
     public function newUnscopedQuery($table = null)
     {
@@ -85,12 +97,12 @@ class Category extends BaseModel
 
     /**
      * Set the value of model's parent id key.
-     *
      * Behind the scenes node is appended to found parent node.
      *
-     * @param int $value
-     *
-     * @throws Exception If parent node doesn't exists
+     * @param  int  $value
+     * @return void
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function setParentIdAttribute($value)
     {
@@ -107,10 +119,10 @@ class Category extends BaseModel
 
     /**
      * Get a new base query that includes deleted nodes.
-     *
      * @since 1.1
      *
-     * @return QueryBuilder
+     * @param  null|string $table
+     * @return \GetCandy\Api\Core\Categories\QueryBuilder
      */
     public function newNestedSetQuery($table = null)
     {
@@ -123,6 +135,8 @@ class Category extends BaseModel
 
     /**
      * Call pending action.
+     * 
+     * @return void
      */
     protected function callPendingAction()
     {
@@ -177,8 +191,9 @@ class Category extends BaseModel
     /**
      * We use our own QueryBuilder here as withDepth was causing
      * a serious query issue when looking through category channels.
-     *
      * @since 2.0
+     * 
+     * @return \GetCandy\Api\Core\Categories\QueryBuilder
      */
     public function newEloquentBuilder($query)
     {

--- a/src/Core/Categories/QueryBuilder.php
+++ b/src/Core/Categories/QueryBuilder.php
@@ -9,8 +9,7 @@ class QueryBuilder extends KalnoyQueryBuilder
     /**
      * Include depth level into the result.
      *
-     * @param string $as
-     *
+     * @param  string  $as
      * @return $this
      */
     public function withDepth($as = 'depth')

--- a/src/Core/Categories/Services/CategoryService.php
+++ b/src/Core/Categories/Services/CategoryService.php
@@ -15,9 +15,13 @@ use GetCandy\Api\Core\Search\SearchContract;
 class CategoryService extends BaseService
 {
     /**
-     * @var AttributeGroup
+     * @var \GetCandy\Api\Core\Categories\Models\Category
      */
     protected $model;
+
+    /**
+     * @var \GetCandy\Api\Core\Routes\Models\Route
+     */
     protected $route;
 
     public function __construct()
@@ -28,9 +32,11 @@ class CategoryService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     * 
+     * @param  string  $id
+     * @return \GetCandy\Api\Core\Categories\Models\Category
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id)
     {
@@ -209,9 +215,9 @@ class CategoryService extends BaseService
     /**
      * Update a category layout.
      *
-     * @param string $categoryId
-     * @param string $layoutId
-     * @return Product
+     * @param  string  $categoryId
+     * @param  string  $layoutId
+     * @return \GetCandy\Api\Core\Categories\Models\Category
      */
     public function updateLayout($categoryId, $layoutId)
     {
@@ -282,11 +288,10 @@ class CategoryService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
+     * @param  string  $id
      * @return bool
+     * 
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function delete($id)
     {

--- a/src/Core/Channels/Factories/ChannelFactory.php
+++ b/src/Core/Channels/Factories/ChannelFactory.php
@@ -9,16 +9,12 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 class ChannelFactory implements ChannelFactoryInterface
 {
     /**
-     * The current channel.
-     *
-     * @var Channel
+     * @var \GetCandy\Api\Core\Channels\Models\Channel
      */
     protected $channel;
 
     /**
-     * The channel service.
-     *
-     * @var ChannelService
+     * @var \GetCandy\Api\Core\Channels\Services\ChannelService
      */
     protected $service;
 
@@ -30,7 +26,7 @@ class ChannelFactory implements ChannelFactoryInterface
     /**
      * Set the value for channel.
      *
-     * @param string|channel $channel
+     * @param  null|string|\GetCandy\Api\Core\Channels\Models\Channel  $channel
      * @return void
      */
     public function set($channel = null)
@@ -44,8 +40,8 @@ class ChannelFactory implements ChannelFactoryInterface
     /**
      * Set the value for channel.
      *
-     * @param string $channel
-     * @return void
+     * @param  string|\GetCandy\Api\Core\Channels\Models\Channel  $channel
+     * @return $this
      */
     public function setChannel($channel)
     {
@@ -64,7 +60,7 @@ class ChannelFactory implements ChannelFactoryInterface
     /**
      * Get the current channel.
      *
-     * @return void
+     * @return \GetCandy\Api\Core\Channels\Models\Channel
      */
     public function getChannel()
     {

--- a/src/Core/Channels/Models/Channel.php
+++ b/src/Core/Channels/Models/Channel.php
@@ -11,6 +11,11 @@ use GetCandy\Api\Core\Shipping\Models\ShippingMethod;
 
 class Channel extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'channel';
 
     /**

--- a/src/Core/Channels/Services/ChannelService.php
+++ b/src/Core/Channels/Services/ChannelService.php
@@ -9,7 +9,7 @@ use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 class ChannelService extends BaseService
 {
     /**
-     * @var AttributeGroup
+     * @var \GetCandy\Api\Core\Channels\Models\Channel
      */
     protected $model;
 
@@ -27,8 +27,7 @@ class ChannelService extends BaseService
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return GetCandy\Api\Core\Models\Channel
+     * @return \GetCandy\Api\Core\Channels\Models\Channel
      */
     public function create(array $data)
     {
@@ -55,13 +54,12 @@ class ChannelService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $id
+     * @param  string  $hashedId
      * @param  array  $data
+     * @return null|\GetCandy\Api\Core\Channels\Models\Channel
      *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
-     *
-     * @return GetCandy\Api\Core\Models\Channel
      */
     public function update($hashedId, array $data)
     {
@@ -83,8 +81,9 @@ class ChannelService extends BaseService
     }
 
     /**
-     * @param $id
-     * @return mixed
+     * @param  string  $id
+     * @return bool|null
+     *
      * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      */
     public function delete($id)

--- a/src/Core/Collections/Drafting/CollectionDrafter.php
+++ b/src/Core/Collections/Drafting/CollectionDrafter.php
@@ -59,8 +59,8 @@ class CollectionDrafter extends BaseDrafter implements DrafterInterface
     /**
      * Duplicate a product.
      *
-     * @param Collection $data
-     * @return Product
+     * @param  \Illuminate\Database\Eloquent\Model  $collection
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function firstOrCreate(Model $collection)
     {

--- a/src/Core/Collections/Models/Collection.php
+++ b/src/Core/Collections/Models/Collection.php
@@ -22,8 +22,16 @@ class Collection extends BaseModel
         Draftable,
         Versionable;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
+    /**
+     * @var string
+     */
     protected $settings = 'collections';
 
     /**

--- a/src/Core/Collections/Services/CollectionService.php
+++ b/src/Core/Collections/Services/CollectionService.php
@@ -9,7 +9,7 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 class CollectionService extends BaseService
 {
     /**
-     * @var AttributeGroup
+     * @var \GetCandy\Api\Core\Collections\Models\Collection
      */
     protected $model;
 
@@ -20,9 +20,12 @@ class CollectionService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Collection
+     * 
+     * @param  string  $id
+     * @param  bool  $withDrafted
+     * @return \GetCandy\Api\Core\Collections\Models\Collection
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id, $withDrafted = false)
     {
@@ -51,8 +54,7 @@ class CollectionService extends BaseService
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return Collection
+     * @return \GetCandy\Api\Core\Collections\Models\Collection
      */
     public function create(array $data)
     {
@@ -72,11 +74,10 @@ class CollectionService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
+     * @param  string  $id
+     * @return bool|null
      *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
-     * @return bool
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function delete($id)
     {
@@ -91,8 +92,10 @@ class CollectionService extends BaseService
 
     /**
      * Gets paginated data for the record.
-     * @param  int $length How many results per page
-     * @param  int  $page   The page to start
+     * 
+     * @param  string  $searchTerm
+     * @param  int  $length
+     * @param  null|int  $page
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getPaginatedData($searchTerm = null, $length = 50, $page = null)
@@ -109,9 +112,10 @@ class CollectionService extends BaseService
 
     /**
      * Sync products to a collection.
-     * @param  string $collectionId
+     * 
+     * @param  string  $collectionId
      * @param  array  $products
-     * @return Collection
+     * @return \GetCandy\Api\Core\Collections\Models\Collection
      */
     public function syncProducts($collectionId, $products = [])
     {

--- a/src/Core/Countries/Models/Country.php
+++ b/src/Core/Countries/Models/Country.php
@@ -7,10 +7,17 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 class Country extends BaseModel
 {
     /**
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'main';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'name',
         'iso_a_2',

--- a/src/Core/Countries/Services/CountryService.php
+++ b/src/Core/Countries/Services/CountryService.php
@@ -15,7 +15,7 @@ class CountryService extends BaseService
     /**
      * Get countries grouped by region.
      *
-     * @return Collection
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getGroupedByRegion()
     {
@@ -31,9 +31,8 @@ class CountryService extends BaseService
     /**
      * Get a country by its name.
      *
-     * @param string $name
-     * @param string $locale
-     * @return Country
+     * @param  string  $name
+     * @return \GetCandy\Api\Core\Countries\Models\Country
      */
     public function getByName($name)
     {

--- a/src/Core/Currencies/CurrencyConverter.php
+++ b/src/Core/Currencies/CurrencyConverter.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 class CurrencyConverter implements CurrencyConverterInterface
 {
     /**
-     * @var \GetCandy\Api\Core\Currencies\Models\Currency|null
+     * @var null|\GetCandy\Api\Core\Currencies\Models\Currency
      */
     protected $currency;
 

--- a/src/Core/Currencies/CurrencyConverter.php
+++ b/src/Core/Currencies/CurrencyConverter.php
@@ -14,8 +14,6 @@ class CurrencyConverter implements CurrencyConverterInterface
     protected $currency;
 
     /**
-     * The currency service.
-     *
      * @var \GetCandy\Api\Core\Currencies\Interfaces\CurrencyServiceInterface
      */
     protected $currencies;

--- a/src/Core/Currencies/CurrencyConverter.php
+++ b/src/Core/Currencies/CurrencyConverter.php
@@ -8,12 +8,15 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class CurrencyConverter implements CurrencyConverterInterface
 {
+    /**
+     * @var \GetCandy\Api\Core\Currencies\Models\Currency|null
+     */
     protected $currency;
 
     /**
      * The currency service.
      *
-     * @var CurrencyServiceInterface
+     * @var \GetCandy\Api\Core\Currencies\Interfaces\CurrencyServiceInterface
      */
     protected $currencies;
 

--- a/src/Core/Currencies/Models/Currency.php
+++ b/src/Core/Currencies/Models/Currency.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Currency extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'currency';
 
     /**

--- a/src/Core/Currencies/Services/CurrencyService.php
+++ b/src/Core/Currencies/Services/CurrencyService.php
@@ -18,8 +18,7 @@ class CurrencyService extends BaseService implements CurrencyServiceInterface
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return GetCandy\Api\Core\Models\Currency
+     * @return \GetCandy\Api\Core\Currencies\Models\Currency
      */
     public function create($data)
     {
@@ -54,13 +53,12 @@ class CurrencyService extends BaseService implements CurrencyServiceInterface
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $id
+     * @param  string  $id
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Currencies\Models\Currency
      *
-     * @throws Symfony\Component\HttpKernel\Exception
+     * @throws \Exception
      * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
-     *
-     * @return GetCandy\Api\Core\Models\Currency
      */
     public function update($id, array $data)
     {
@@ -101,12 +99,11 @@ class CurrencyService extends BaseService implements CurrencyServiceInterface
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
-     *
+     * @param  string  $id
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      */
     public function delete($id)
     {

--- a/src/Core/Customers/Models/CustomerGroup.php
+++ b/src/Core/Customers/Models/CustomerGroup.php
@@ -12,6 +12,8 @@ use GetCandy\Api\Core\Shipping\Models\ShippingPrice;
 class CustomerGroup extends BaseModel
 {
     /**
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'main';
@@ -25,7 +27,7 @@ class CustomerGroup extends BaseModel
     }
 
     /**
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function products()
     {
@@ -33,7 +35,7 @@ class CustomerGroup extends BaseModel
     }
 
     /**
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function collections()
     {
@@ -41,7 +43,7 @@ class CustomerGroup extends BaseModel
     }
 
     /**
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function categories()
     {

--- a/src/Core/Customers/Services/CustomerService.php
+++ b/src/Core/Customers/Services/CustomerService.php
@@ -14,8 +14,9 @@ class CustomerService extends BaseService
 
     /**
      * Registers a new customer.
+     * 
      * @param  array  $data
-     * @return [type]       [description]
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function register(array $data)
     {
@@ -29,9 +30,12 @@ class CustomerService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     * 
+     * @param  string  $id
+     * @param  array  $includes
+     * @return \Illuminate\Database\Eloquent\Model
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id, $includes = [])
     {

--- a/src/Core/Discounts/DiscountFactory.php
+++ b/src/Core/Discounts/DiscountFactory.php
@@ -10,7 +10,7 @@ class DiscountFactory implements DiscountInterface
     /**
      * The discount models.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Database\Eloquent\Collection
      */
     protected $discounts;
 
@@ -31,8 +31,7 @@ class DiscountFactory implements DiscountInterface
     /**
      * Initialise the factory.
      *
-     * @param mixed $discounts
-     * @return DiscountFactory
+     * @return $this
      */
     public function init()
     {
@@ -45,8 +44,8 @@ class DiscountFactory implements DiscountInterface
     /**
      * Set the basket.
      *
-     * @param Basket $basket
-     * @return DiscountFactory
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @return $this
      */
     public function setBasket(Basket $basket)
     {
@@ -58,8 +57,8 @@ class DiscountFactory implements DiscountInterface
     /**
      * Set the user.
      *
-     * @param Model $user
-     * @return DiscountFactory
+     * @param  null|\Illuminate\Database\Eloquent\Model  $user
+     * @return $this
      */
     public function setUser(Model $user = null)
     {
@@ -71,7 +70,7 @@ class DiscountFactory implements DiscountInterface
     /**
      * Get all applied discounts.
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function getApplied()
     {
@@ -91,9 +90,9 @@ class DiscountFactory implements DiscountInterface
     /**
      * Checks the criteria.
      *
-     * @param Discount $discount
-     * @param mixed $uesr
-     * @param Basket $basket
+     * @param  \GetCandy\Api\Core\Discounts\Discount  $discount
+     * @param  null|\Illuminate\Database\Eloquent\Model  $user
+     * @param  null|\GetCandy\Api\Core\Baskets\Models\Basket  $basket
      * @return bool
      */
     public function checkCriteria($discount, $user = null, $basket = null)

--- a/src/Core/Discounts/Entities/Discount.php
+++ b/src/Core/Discounts/Entities/Discount.php
@@ -10,8 +10,14 @@ class Discount
 
     protected $model;
 
+    /**
+     * @var \Illuminate\Support\Collection
+     */
     protected $criteria;
 
+    /**
+     * @var \GetCandy\Api\Core\Discounts\RewardSet
+     */
     protected $reward;
 
     public function __construct()
@@ -19,6 +25,10 @@ class Discount
         $this->criteria = collect();
     }
 
+    /**
+     * @param  \GetCandy\Api\Core\Discounts\RewardSet  $reward
+     * @return $this
+     */
     public function setReward(RewardSet $reward)
     {
         $this->reward = $reward;
@@ -26,6 +36,10 @@ class Discount
         return $this;
     }
 
+    /**
+     * @param  \GetCandy\Api\Core\Discounts\CriteriaSet  $criteria
+     * @return $this
+     */
     public function addCriteria(CriteriaSet $criteria)
     {
         $this->criteria->push($criteria);

--- a/src/Core/Discounts/Factory.php
+++ b/src/Core/Discounts/Factory.php
@@ -7,6 +7,9 @@ use GetCandy\Api\Core\Discounts\Criteria\ProductIn;
 
 class Factory
 {
+    /**
+     * @var array
+     */
     protected $rewards = [];
 
     public function getApplied($discounts, $user, $product = null, $basket = null, $area = 'catalog')
@@ -26,10 +29,11 @@ class Factory
     /**
      * Checks the criteria.
      *
-     * @param Discount $discount
-     * @param mixed $uesr
-     * @param Basket $basket
-     * @return void
+     * @param  \GetCandy\Api\Core\Discounts\Discount  $discount
+     * @param  null|\Illuminate\Database\Eloquent\Model  $user
+     * @param  null|\GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @param  null|\GetCandy\Api\Core\Products\Models\Product  $product
+     * @return bool
      */
     public function checkCriteria($discount, $user = null, $basket = null, $product = null)
     {

--- a/src/Core/Discounts/Listeners/AddDiscountToProductListener.php
+++ b/src/Core/Discounts/Listeners/AddDiscountToProductListener.php
@@ -7,6 +7,9 @@ use GetCandy\Api\Core\Products\Events\ProductViewedEvent;
 
 class AddDiscountToProductListener
 {
+    /**
+     * @var \GetCandy\Api\Core\Discounts\Factory
+     */
     protected $factory;
 
     public function __construct(Factory $factory)
@@ -17,7 +20,7 @@ class AddDiscountToProductListener
     /**
      * Handle the event.
      *
-     * @param  OrderShipped  $event
+     * @param  \GetCandy\Api\Core\Products\Events\ProductViewedEvent  $event
      * @return void
      */
     public function handle(ProductViewedEvent $event)

--- a/src/Core/Discounts/Models/Discount.php
+++ b/src/Core/Discounts/Models/Discount.php
@@ -11,6 +11,11 @@ class Discount extends BaseModel
     use HasAttributes,
         HasChannels;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public function sets()

--- a/src/Core/Discounts/Models/DiscountCriteriaItem.php
+++ b/src/Core/Discounts/Models/DiscountCriteriaItem.php
@@ -8,8 +8,18 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class DiscountCriteriaItem extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = ['type', 'value'];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public function set()
@@ -39,7 +49,7 @@ class DiscountCriteriaItem extends BaseModel
     /**
      * Checks whether a product is eligible.
      *
-     * @param Basket $basket
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
      * @return bool
      */
     protected function checkWithProduct($basket)
@@ -63,6 +73,8 @@ class DiscountCriteriaItem extends BaseModel
 
     /**
      * Get all of the owning commentable models.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function eligibles()
     {

--- a/src/Core/Discounts/Models/DiscountCriteriaSet.php
+++ b/src/Core/Discounts/Models/DiscountCriteriaSet.php
@@ -6,8 +6,18 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class DiscountCriteriaSet extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = ['scope', 'outcome'];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public function discount()
@@ -23,8 +33,8 @@ class DiscountCriteriaSet extends BaseModel
     /**
      * Process a criteria set.
      *
-     * @param \Illuminate\Eloquent\Database\Model $user
-     * @param \GetCandy\Core\Baskets\Models\Basket $basket
+     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
      * @return bool
      */
     public function process($user, $basket)

--- a/src/Core/Discounts/Models/DiscountReward.php
+++ b/src/Core/Discounts/Models/DiscountReward.php
@@ -6,8 +6,18 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class DiscountReward extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = ['value', 'type', 'product_id'];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public function discount()

--- a/src/Core/Discounts/Models/DiscountRewardProduct.php
+++ b/src/Core/Discounts/Models/DiscountRewardProduct.php
@@ -7,8 +7,18 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class DiscountRewardProduct extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = ['product_id', 'quantity'];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public function reward()

--- a/src/Core/Discounts/Services/DiscountService.php
+++ b/src/Core/Discounts/Services/DiscountService.php
@@ -20,9 +20,8 @@ class DiscountService extends BaseService
     /**
      * Create a discount.
      *
-     * @param array $data
-     *
-     * @return Discount
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Discounts\Models\Discount
      */
     public function create(array $data)
     {
@@ -57,10 +56,9 @@ class DiscountService extends BaseService
     /**
      * Update an existing discount.
      *
-     * @param string $id
-     * @param array $data
-     *
-     * @return Discount
+     * @param  string  $id
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Discounts\Models\Discount
      */
     public function update($id, array $data)
     {
@@ -96,10 +94,9 @@ class DiscountService extends BaseService
     /**
      * Set up sets and rewards with a discount.
      *
-     * @param Discount $discount
-     * @param array $sets
-     *
-     * @return Discount
+     * @param  \GetCandy\Api\Core\Discounts\Models\Discount  $discount
+     * @param  array  $sets
+     * @return \GetCandy\Api\Core\Discounts\Models\Discount
      */
     public function syncSets($discount, array $sets)
     {
@@ -130,10 +127,9 @@ class DiscountService extends BaseService
     /**
      * Sync up rewards for a discount.
      *
-     * @param Discount $discount
-     * @param array $rewards
-     *
-     * @return void
+     * @param  \GetCandy\Api\Core\Discounts\Models\Discount  $discount
+     * @param  array  $rewards
+     * @return \GetCandy\Api\Core\Discounts\Models\Discount
      */
     public function syncRewards($discount, array $rewards)
     {
@@ -152,7 +148,7 @@ class DiscountService extends BaseService
     /**
      * Get All the discounts.
      *
-     * @return array
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function get()
     {
@@ -161,9 +157,12 @@ class DiscountService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     * 
+     * @param  string  $id
+     * @param  array  $relations
+     * @return \GetCandy\Api\Core\Discounts\Models\Discount
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id, $relations = null)
     {

--- a/src/Core/Discounts/Validators/DiscountValidator.php
+++ b/src/Core/Discounts/Validators/DiscountValidator.php
@@ -8,6 +8,9 @@ use GetCandy\Api\Core\Discounts\Factory;
 
 class DiscountValidator
 {
+    /**
+     * @var \GetCandy\Api\Core\Baskets\BasketCriteria
+     */
     protected $baskets;
 
     public function __construct(BasketCriteria $baskets)

--- a/src/Core/Drafting/BaseDrafter.php
+++ b/src/Core/Drafting/BaseDrafter.php
@@ -7,7 +7,8 @@ abstract class BaseDrafter
     /**
      * Process the assets for a duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \Illuminate\Database\Eloquent\Model  $old
+     * @param  \Illuminate\Database\Eloquent\Model  $new
      * @return void
      */
     protected function processAssets($old, &$new)
@@ -26,7 +27,8 @@ abstract class BaseDrafter
     /**
      * Process the customer groups for the duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \Illuminate\Database\Eloquent\Model  $old
+     * @param  \Illuminate\Database\Eloquent\Model  $new
      * @return void
      */
     protected function processCustomerGroups($old, &$new)
@@ -51,7 +53,8 @@ abstract class BaseDrafter
     /**
      * Process channels for a duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \Illuminate\Database\Eloquent\Model  $old
+     * @param  \Illuminate\Database\Eloquent\Model  $new
      * @return void
      */
     protected function processChannels($old, &$new)

--- a/src/Core/Factory.php
+++ b/src/Core/Factory.php
@@ -47,12 +47,12 @@ use GetCandy\Api\Core\Users\Services\UserService;
 class Factory
 {
     /**
-     * @var AddressService
+     * @var \GetCandy\Api\Core\Addresses\Services\AddressService
      */
     protected $addresses;
 
     /**
-     * @var AssetService
+     * @var \GetCandy\Api\Core\Assets\Services\AssetService
      */
     protected $assets;
 
@@ -67,162 +67,162 @@ class Factory
     protected $associationGroups;
 
     /**
-     * @var AttributeService
+     * @var \GetCandy\Api\Core\Attributes\Services\AttributeService
      */
     protected $attributes;
 
     /**
-     * @var AttributeGroupService
+     * @var \GetCandy\Api\Core\Attributes\Services\AttributeGroupService
      */
     protected $attributeGroups;
 
     /**
-     * @var BasketService
+     * @var \GetCandy\Api\Core\Baskets\Services\BasketService
      */
     protected $baskets;
 
     /**
-     * @var SavedBasketService
+     * @var \GetCandy\Api\Core\Baskets\Services\SavedBasketService
      */
     protected $savedBaskets;
 
     /**
-     * @var BasketLineService
+     * @var \GetCandy\Api\Core\Baskets\Services\BasketLineService
      */
     protected $basketLines;
 
     /**
-     * @var CategoryService
+     * @var \GetCandy\Api\Core\Categories\Services\CategoryService
      */
     protected $categories;
 
     /**
-     * @var ChannelService
+     * @var \GetCandy\Api\Core\Channels\Services\ChannelService
      */
     protected $channels;
 
     /**
-     * @var CountryService
+     * @var \GetCandy\Api\Core\Countries\Services\CountryService
      */
     protected $countries;
 
     /**
-     * @var CurrencyService
+     * @var \GetCandy\Api\Core\Currencies\Services\CurrencyService
      */
     protected $currencies;
 
     /**
-     * @var CustomerService
+     * @var \GetCandy\Api\Core\Customers\Services\CustomerService
      */
     protected $customers;
 
     /**
-     * @var DiscountService
+     * @var \GetCandy\Api\Core\Discounts\Services\DiscountService
      */
     protected $discounts;
 
     /**
-     * @var LayoutService
+     * @var \GetCandy\Api\Core\Layouts\Services\LayoutService
      */
     protected $layouts;
 
     /**
-     * @var LanguageService
+     * @var \GetCandy\Api\Core\Languages\Services\LanguageService
      */
     protected $languages;
 
     /**
-     * @var OrderService
+     * @var \GetCandy\Api\Core\Orders\Services\OrderService
      */
     protected $orders;
 
     /**
-     * @var PaymentService
+     * @var \GetCandy\Api\Core\Payments\Services\PaymentService
      */
     protected $payments;
 
     /**
-     * @var PaymentTypeService
+     * @var \GetCandy\Api\Core\Payments\Services\PaymentTypeService
      */
     protected $paymentTypes;
 
     /**
-     * @var PageService
+     * @var \GetCandy\Api\Core\Pages\Services\PageService
      */
     protected $pages;
 
     /**
-     * @var ProductService
+     * @var \GetCandy\Api\Core\Products\Services\ProductService
      */
     protected $products;
 
     /**
-     * @var ProductAssociationService
+     * @var \GetCandy\Api\Core\Products\Services\ProductAssociationService
      */
     protected $productAssociations;
 
     /**
-     * @var ProductFamilyService
+     * @var \GetCandy\Api\Core\Products\Services\ProductCollectionService
      */
     protected $productCollections;
 
     /**
-     * @var ProductFamilyService
+     * @var \GetCandy\Api\Core\Products\Services\ProductFamilyService
      */
     protected $productFamilies;
 
     /**
-     * @var ProductVariantService
+     * @var \GetCandy\Api\Core\Products\Services\ProductVariantService
      */
     protected $productVariants;
 
     /**
-     * @var RouteService
+     * @var \GetCandy\Api\Core\Routes\Services\RouteService
      */
     protected $routes;
 
     /**
-     * @var RoleService
+     * @var \GetCandy\Api\Core\Auth\Services\RoleService
      */
     protected $roles;
 
     /**
-     * @var SavedSearchService
+     * @var \GetCandy\Api\Core\Search\Services\SavedSearchService
      */
     protected $savedSearch;
 
     /**
-     * @var \GetCandy\Api\Core\Services\SearchService;
+     * @var \GetCandy\Api\Core\Search\Services\SearchService
      */
     protected $search;
 
     /**
-     * @var \GetCandy\Api\Core\SettingService
+     * @var \GetCandy\Api\Core\Settings\Services\SettingService
      */
     protected $settings;
 
     /**
-     * @var ShippingMethodService
+     * @var \GetCandy\Api\Core\Shipping\Services\ShippingMethodService
      */
     protected $shippingMethods;
 
     /**
-     * @var ShippingPriceService
+     * @var \GetCandy\Api\Core\Shipping\Services\ShippingPriceService
      */
     protected $shippingPrices;
 
     /**
-     * @var ShippingZoneService
+     * @var \GetCandy\Api\Core\Shipping\Services\ShippingZoneService
      */
     protected $shippingZones;
 
     /**
-     * @var TagService
+     * @var \GetCandy\Api\Core\Tags\Services\TagService
      */
     protected $tags;
 
     /**
-     * @var TaxService
+     * @var \GetCandy\Api\Core\Taxes\Services\TaxService
      */
     protected $taxes;
 
@@ -232,7 +232,7 @@ class Factory
     protected $transforms;
 
     /**
-     * @var UserService
+     * @var \GetCandy\Api\Core\Users\Services\UserService
      */
     protected $users;
 
@@ -333,6 +333,5 @@ class Factory
         return app()->make(
             get_class($this->{$name})
         );
-        // return ;
     }
 }

--- a/src/Core/GetCandy.php
+++ b/src/Core/GetCandy.php
@@ -8,8 +8,14 @@ use Illuminate\Support\Facades\Route;
 
 class GetCandy
 {
+    /**
+     * @var bool
+     */
     protected $isHubRequest = false;
 
+    /**
+     * @var array
+     */
     protected $groups = [];
 
     public function setGroups($groups)
@@ -43,10 +49,10 @@ class GetCandy
     }
 
     /**
-     * Sets whether it's a hub request or not.
+     * Sets whether it's a Hub request or not.
      *
-     * @param bool $bool
-     * @return self
+     * @param  bool  $bool
+     * @return $this
      */
     public function setIsHubRequest($bool)
     {

--- a/src/Core/Languages/Models/Language.php
+++ b/src/Core/Languages/Models/Language.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Language extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'language';
 
     /**

--- a/src/Core/Languages/Services/LanguageService.php
+++ b/src/Core/Languages/Services/LanguageService.php
@@ -17,8 +17,7 @@ class LanguageService extends BaseService
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return GetCandy\Api\Core\Models\Language
+     * @return \GetCandy\Api\Core\Languages\Models\Language
      */
     public function create($data)
     {
@@ -48,13 +47,14 @@ class LanguageService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $id
+     * @param  string  $hashedId
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Languages\Models\Language
      *
-     * @throws Symfony\Component\HttpKernel\Exception
+     * @throws \Exception
      * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      *
-     * @return GetCandy\Api\Core\Models\Language
+     * 
      */
     public function update($hashedId, array $data)
     {
@@ -99,12 +99,11 @@ class LanguageService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
-     *
+     * @param  string  $id
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      */
     public function delete($id)
     {
@@ -130,6 +129,7 @@ class LanguageService extends BaseService
 
     /**
      * Checks all locales in the array exist.
+     * 
      * @param  array  $locales
      * @return bool
      */

--- a/src/Core/Layouts/Models/Layout.php
+++ b/src/Core/Layouts/Models/Layout.php
@@ -6,5 +6,10 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Layout extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 }

--- a/src/Core/Layouts/Services/LayoutService.php
+++ b/src/Core/Layouts/Services/LayoutService.php
@@ -15,8 +15,8 @@ class LayoutService extends BaseService
     /**
      * Create a new layout.
      *
-     * @param array $data
-     * @return Layout
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Layouts\Models\Layout
      */
     public function create(array $data)
     {
@@ -32,9 +32,9 @@ class LayoutService extends BaseService
     /**
      * Update an existing layout.
      *
-     * @param string $id
-     * @param array $data
-     * @return Layout
+     * @param  string  $id
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Layouts\Models\Layout
      */
     public function update($id, array $data)
     {

--- a/src/Core/Orders/Events/OrderBeforeSavedEvent.php
+++ b/src/Core/Orders/Events/OrderBeforeSavedEvent.php
@@ -6,12 +6,15 @@ use GetCandy\Api\Core\Orders\Models\Order;
 
 class OrderBeforeSavedEvent
 {
+    /**
+     * @var \GetCandy\Api\Core\Orders\Models\Order
+     */
     public $order;
 
     /**
      * Create a new event instance.
      *
-     * @param  Order  $order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
      * @return void
      */
     public function __construct(Order $order)

--- a/src/Core/Orders/Events/OrderProcessedEvent.php
+++ b/src/Core/Orders/Events/OrderProcessedEvent.php
@@ -6,12 +6,15 @@ use GetCandy\Api\Core\Orders\Models\Order;
 
 class OrderProcessedEvent
 {
+    /**
+     * @var \GetCandy\Api\Core\Orders\Models\Order
+     */
     public $order;
 
     /**
      * Create a new event instance.
      *
-     * @param  Order  $order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
      * @return void
      */
     public function __construct(Order $order)

--- a/src/Core/Orders/Events/OrderRefundEvent.php
+++ b/src/Core/Orders/Events/OrderRefundEvent.php
@@ -10,21 +10,22 @@ class OrderRefundEvent
     /**
      * The related order.
      *
-     * @var Order
+     * @var \GetCandy\Api\Core\Orders\Models\Order
      */
     public $order;
 
     /**
      * The refunded transaction.
      *
-     * @var Transaction
+     * @var \GetCandy\Api\Core\Payments\Models\Transaction
      */
     public $transaction;
 
     /**
      * Create a new event instance.
      *
-     * @param  Order  $order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  \GetCandy\Api\Core\Payments\Models\Transaction  $transaction
      * @return void
      */
     public function __construct(Order $order, Transaction $transaction)

--- a/src/Core/Orders/Events/OrderSavedEvent.php
+++ b/src/Core/Orders/Events/OrderSavedEvent.php
@@ -7,14 +7,21 @@ use GetCandy\Api\Core\Orders\Models\Order;
 
 class OrderSavedEvent
 {
+    /**
+     * @var \GetCandy\Api\Core\Orders\Models\Order
+     */
     public $order;
 
+    /**
+     * @var \GetCandy\Api\Core\Baskets\Models\Basket
+     */
     public $basket;
 
     /**
      * Create a new event instance.
      *
-     * @param  Order  $order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  null|\GetCandy\Api\Core\Baskets\Models\Basket  $basket
      * @return void
      */
     public function __construct(Order $order, Basket $basket = null)

--- a/src/Core/Orders/Factories/OrderFactory.php
+++ b/src/Core/Orders/Factories/OrderFactory.php
@@ -24,14 +24,14 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * The basket model.
      *
-     * @var Basket
+     * @var \GetCandy\Api\Core\Baskets\Models\Basket
      */
     protected $basket;
 
     /**
      * The order model instance.
      *
-     * @var Order
+     * @var \GetCandy\Api\Core\Orders\Models\Order
      */
     protected $order;
 
@@ -45,14 +45,14 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * The site settings provider.
      *
-     * @var SettingService
+     * @var \GetCandy\Api\Core\Settings\Services\SettingService
      */
     protected $settings;
 
     /**
      * The shipping model instance.
      *
-     * @var ShippingPrice
+     * @var \GetCandy\Api\Core\Shipping\Models\ShippingPrice
      */
     protected $shipping;
 
@@ -66,26 +66,32 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * The currencies instance.
      *
-     * @var CurrencyConverterInterface
+     * @var \GetCandy\Api\Core\Currencies\Interfaces\CurrencyConverterInterface
      */
     protected $currencies;
 
     /**
      * The price calculator instance.
      *
-     * @var PriceCalculatorInterface
+     * @var \GetCandy\Api\Core\Pricing\PriceCalculatorInterface
      */
     protected $calculator;
 
     /**
      * The product variants factory.
      *
-     * @var ProductVariantFactory
+     * @var \GetCandy\Api\Core\Products\Interfaces\ProductVariantInterface
      */
     protected $variants;
 
+    /**
+     * @var array
+     */
     protected $includes = [];
 
+    /**
+     * @var \GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface
+     */
     protected $tax;
 
     /**
@@ -112,8 +118,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Set the value for user.
      *
-     * @param User $user
-     * @return self
+     * @param  \Illuminate\Foundation\Auth\User  $user
+     * @return $this
      */
     public function user(User $user = null)
     {
@@ -125,8 +131,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Set the value for type.
      *
-     * @param string $type
-     * @return self
+     * @param  string  $type
+     * @return $this
      */
     public function type($type)
     {
@@ -145,8 +151,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Set the value for basket.
      *
-     * @param Basket $basket
-     * @return self
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @return $this
      */
     public function basket(Basket $basket)
     {
@@ -162,8 +168,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Set the value of order.
      *
-     * @param Order $order
-     * @return self
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return $this
      */
     public function order(Order $order)
     {
@@ -175,7 +181,7 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Get the value for basket.
      *
-     * @return Basket
+     * @return \GetCandy\Api\Core\Baskets\Models\Basket
      */
     public function getBasket()
     {
@@ -185,7 +191,7 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Get the value for user.
      *
-     * @return User
+     * @return \Illuminate\Foundation\Auth\User
      */
     public function getUser()
     {
@@ -195,7 +201,7 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Resolve the basket to an order.
      *
-     * @return Order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function resolve()
     {
@@ -243,8 +249,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Resolve the lines for our order.
      *
-     * @param Order $order
-     * @return Order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function resolveLines(&$order)
     {
@@ -289,8 +295,9 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Get the active order.
      *
-     * @throws BasketHasPlacedOrderException
-     * @return Order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
+     * 
+     * @throws \GetCandy\Api\Core\Orders\Exceptions\BasketHasPlacedOrderException
      */
     protected function getActiveOrder()
     {
@@ -306,7 +313,7 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Create a new order.
      *
-     * @return Order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function createNewOrder()
     {
@@ -325,10 +332,9 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Sets the fields for contact info on the order.
      *
-     * @param string $order
-     * @param array $fields
-     * @param string $prefix
-     *
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  array  $fields
+     * @param  string  $prefix
      * @return void
      */
     protected function setFields($order, $fields, $prefix)
@@ -346,8 +352,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Sets the user fields.
      *
-     * @param Order $order
-     * @return Order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function setUserFields(&$order)
     {
@@ -365,8 +371,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Recalculates an orders totals.
      *
-     * @param Order $order
-     * @return Order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function recalculate($order)
     {
@@ -422,9 +428,9 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Set the value for shipping price with preference.
      *
-     * @param ShippingPrice $price
-     * @param string $preference
-     * @return self
+     * @param  \GetCandy\Api\Core\Shipping\Models\ShippingPrice  $price
+     * @param  null|string  $preference
+     * @return $this
      */
     public function shipping(ShippingPrice $price, $preference = null)
     {
@@ -437,8 +443,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Adds a shipping line to an order.
      *
-     * @param Order $order
-     * @return Order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function addShippingLine(&$order)
     {
@@ -490,8 +496,8 @@ class OrderFactory implements OrderFactoryInterface
     /**
      * Resolve the discounts to an order.
      *
-     * @param Order $order
-     * @return Order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function resolveDiscounts(&$order)
     {

--- a/src/Core/Orders/Factories/OrderProcessingFactory.php
+++ b/src/Core/Orders/Factories/OrderProcessingFactory.php
@@ -21,21 +21,21 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * The order instance.
      *
-     * @var Order
+     * @var \GetCandy\Api\Core\Orders\Models\Order
      */
     protected $order;
 
     /**
      * Additional payload fields.
      *
-     * @var string
+     * @var array
      */
     protected $payload = [];
 
     /**
      * The payment provider.
      *
-     * @var PaymentType
+     * @var \GetCandy\Api\Core\Payments\Models\PaymentType
      */
     protected $provider;
 
@@ -49,7 +49,7 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * The payment manager instance.
      *
-     * @var PaymentManager
+     * @var \GetCandy\Api\Core\Payments\PaymentContract
      */
     protected $manager;
 
@@ -96,8 +96,8 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Set the value for nonce.
      *
-     * @param string $nonce
-     * @return self
+     * @param  string  $nonce
+     * @return $this
      */
     public function nonce($nonce)
     {
@@ -129,8 +129,8 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Set the value for provider.
      *
-     * @param PaymentType $provider
-     * @return self
+     * @param  null|\GetCandy\Api\Core\Payments\Models\PaymentType  $provider
+     * @return $this
      */
     public function provider(PaymentType $provider = null)
     {
@@ -142,8 +142,8 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Set a value to the payload.
      *
-     * @param string $reference
-     * @return self
+     * @param  string  $reference
+     * @return $this
      */
     public function set($key, $value)
     {
@@ -155,8 +155,8 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Set the value for type.
      *
-     * @param null|string $type
-     * @return self
+     * @param  null|string  $type
+     * @return $this
      */
     public function type($type = null)
     {
@@ -168,8 +168,8 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Set the value for notes.
      *
-     * @param string $notes
-     * @return void
+     * @param  null|string $notes
+     * @return $this
      */
     public function notes($notes = null)
     {
@@ -195,8 +195,8 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Set the value of order.
      *
-     * @param Order $order
-     * @return void
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return $this
      */
     public function order($order)
     {
@@ -244,8 +244,8 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Handle the response from the payment driver.
      *
-     * @param PaymentResponse $response
-     * @return void
+     * @param  \GetCandy\Api\Core\Payments\PaymentResponse  $response
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function processResponse(PaymentResponse $response)
     {
@@ -286,7 +286,7 @@ class OrderProcessingFactory implements OrderProcessingFactoryInterface
     /**
      * Get the order instance.
      *
-     * @return Order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function getOrder()
     {

--- a/src/Core/Orders/Jobs/ProcessRecommendedProducts.php
+++ b/src/Core/Orders/Jobs/ProcessRecommendedProducts.php
@@ -20,7 +20,7 @@ class ProcessRecommendedProducts implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param  Podcast  $podcast
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $podcast
      * @return void
      */
     public function __construct(Order $order)
@@ -31,19 +31,7 @@ class ProcessRecommendedProducts implements ShouldQueue
     /**
      * Execute the job.
      *
-     * @param  AudioProcessor  $processor
      * @return void
-     *
-     * select ol2.sku, count(ol2.sku)
-     * from orders as o
-     * inner join order_lines as ol1 on ol1.`order_id` = o.id
-     * inner join order_lines as ol2 on (ol2.`order_id` = o.id and ol2.id != ol1.id)
-     * where ol1.`sku` = '4999610'
-     *
-     * group by ol2.sku
-     * order by count(ol2.sku) desc
-     *
-     * limit 10
      */
     public function handle()
     {

--- a/src/Core/Orders/Listeners/RefreshOrderListener.php
+++ b/src/Core/Orders/Listeners/RefreshOrderListener.php
@@ -9,7 +9,7 @@ class RefreshOrderListener
     /**
      * Handle the event.
      *
-     * @param  OrderShipped  $event
+     * @param  \GetCandy\Api\Core\Orders\Events\OrderSavedEvent  $event
      * @return void
      */
     public function handle(OrderSavedEvent $event)

--- a/src/Core/Orders/Listeners/SyncWithBasketListener.php
+++ b/src/Core/Orders/Listeners/SyncWithBasketListener.php
@@ -7,6 +7,9 @@ use GetCandy\Api\Core\Discounts\Factory;
 
 class SyncWithBasketListener
 {
+    /**
+     * @var \GetCandy\Api\Core\Discounts\Factory
+     */
     protected $factory;
 
     public function __construct(Factory $factory)
@@ -17,7 +20,7 @@ class SyncWithBasketListener
     /**
      * Handle the event.
      *
-     * @param  OrderShipped  $event
+     * @param  \GetCandy\Api\Core\Baskets\Events\BasketStoredEvent  $event
      * @return void
      */
     public function handle(BasketStoredEvent $event)

--- a/src/Core/Orders/Models/Order.php
+++ b/src/Core/Orders/Models/Order.php
@@ -17,6 +17,11 @@ class Order extends BaseModel
 
     protected static $recordEvents = ['created'];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'order';
 
     protected $guarded = [];
@@ -64,8 +69,8 @@ class Order extends BaseModel
     /**
      * Define the placed scope.
      *
-     * @param Builder $qb
-     * @return Builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $qb
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopePlaced($qb)
     {
@@ -75,9 +80,9 @@ class Order extends BaseModel
     /**
      * Define the Zone scope.
      *
-     * @param Builder $qb
-     * @param string $zone
-     * @return Builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $qb
+     * @param  string  $zone
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeZone($qb, $zone)
     {
@@ -93,10 +98,10 @@ class Order extends BaseModel
     /**
      * Define the date range scope.
      *
-     * @param Builder $qb
-     * @param string $from
-     * @param string $to
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Builder  $qb
+     * @param  string  $from
+     * @param  null|string  $to
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeRange($qb, $from, $to = null)
     {
@@ -113,9 +118,9 @@ class Order extends BaseModel
     /**
      * Define the type scope.
      *
-     * @param Builder $qb
-     * @param string $type
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Builder  $qb
+     * @param  string  $type
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeType($qb, $type)
     {
@@ -134,9 +139,9 @@ class Order extends BaseModel
     /**
      * Define the status scope.
      *
-     * @param Builder $qb
-     * @param string $status
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Builder  $qb
+     * @param  string  $status
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeStatus($qb, $status)
     {
@@ -150,9 +155,9 @@ class Order extends BaseModel
     /**
      * Define the search scope.
      *
-     * @param Builder $qb
-     * @param string $keywords
-     * @return Builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $qb
+     * @param  string  $keywords
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeSearch($qb, $keywords)
     {
@@ -223,8 +228,7 @@ class Order extends BaseModel
     /**
      * Gets the details, mainly for contact info.
      *
-     * @param string $type
-     *
+     * @param  string  $type
      * @return array
      */
     public function getDetails($type)
@@ -271,7 +275,7 @@ class Order extends BaseModel
     /**
      * Get the basket lines.
      *
-     * @return void
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function lines()
     {
@@ -281,7 +285,7 @@ class Order extends BaseModel
     /**
      * Gets all order lines that are from the basket.
      *
-     * @return void
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function basketLines()
     {
@@ -301,7 +305,7 @@ class Order extends BaseModel
     /**
      * Get the basket user.
      *
-     * @return User
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user()
     {

--- a/src/Core/Orders/Models/OrderDiscount.php
+++ b/src/Core/Orders/Models/OrderDiscount.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class OrderDiscount extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'order';
 
     protected $fillable = ['order_id', 'coupon', 'name', 'description', 'amount', 'type'];

--- a/src/Core/Orders/Models/OrderLine.php
+++ b/src/Core/Orders/Models/OrderLine.php
@@ -10,6 +10,11 @@ class OrderLine extends BaseModel
 {
     use HasMeta;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'order';
 
     protected $guarded = [];

--- a/src/Core/Orders/OrderCriteria.php
+++ b/src/Core/Orders/OrderCriteria.php
@@ -25,7 +25,7 @@ class OrderCriteria extends AbstractCriteria implements OrderCriteriaInterface
     /**
      * The user to get the orders for.
      *
-     * @var \Illuminate\Eloquent\Database\Model
+     * @var \Illuminate\Foundation\Auth\User
      */
     protected $user;
 
@@ -85,6 +85,9 @@ class OrderCriteria extends AbstractCriteria implements OrderCriteriaInterface
      */
     protected $scopes = [];
 
+    /**
+     * @var array
+     */
     protected $includes = [];
 
     /**
@@ -97,14 +100,14 @@ class OrderCriteria extends AbstractCriteria implements OrderCriteriaInterface
     /**
      * What user to restrict the query to.
      *
-     * @var string
+     * @var bool
      */
     protected $restrict = true;
 
     /**
      * Set the sort by field.
      *
-     * @var string
+     * @var null|string
      */
     protected $sortBy = null;
 
@@ -118,9 +121,9 @@ class OrderCriteria extends AbstractCriteria implements OrderCriteriaInterface
     /**
      * Set a value on the criteria.
      *
-     * @param string $key
-     * @param mixed $value
-     * @return self
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return $this
      */
     public function set($key, $value)
     {
@@ -134,8 +137,8 @@ class OrderCriteria extends AbstractCriteria implements OrderCriteriaInterface
     /**
      * Fill the criteria.
      *
-     * @param array $values
-     * @return self
+     * @param  array  $values
+     * @return $this
      */
     public function fill($values = [])
     {
@@ -156,7 +159,7 @@ class OrderCriteria extends AbstractCriteria implements OrderCriteriaInterface
     /**
      * Get all the criteria params.
      *
-     * @return void
+     * @return array
      */
     public function toParams()
     {
@@ -188,7 +191,7 @@ class OrderCriteria extends AbstractCriteria implements OrderCriteriaInterface
     /**
      * Get the result from our defined criteria.
      *
-     * @return string
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function get()
     {

--- a/src/Core/Orders/OrderExport.php
+++ b/src/Core/Orders/OrderExport.php
@@ -27,8 +27,8 @@ class OrderExport
     /**
      * Set the value for format.
      *
-     * @param string $format
-     * @return self
+     * @param  string  $format
+     * @return $this
      */
     public function setFormat($format)
     {
@@ -50,8 +50,8 @@ class OrderExport
     /**
      * Set the value for content.
      *
-     * @param string $content
-     * @return self
+     * @param  string  $content
+     * @return $this
      */
     public function setContent($content)
     {

--- a/src/Core/Orders/OrderSearchCriteria.php
+++ b/src/Core/Orders/OrderSearchCriteria.php
@@ -23,7 +23,7 @@ class OrderSearchCriteria
     /**
      * The user to get the orders for.
      *
-     * @var \Illuminate\Eloquent\Database\Model
+     * @var \Illuminate\Foundation\Auth\User
      */
     protected $user;
 
@@ -86,16 +86,16 @@ class OrderSearchCriteria
     /**
      * What user to restrict the query to.
      *
-     * @var string
+     * @var bool
      */
     protected $restrict = true;
 
     /**
      * Set a value on the criteria.
      *
-     * @param string $key
-     * @param mixed $value
-     * @return self
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return $this
      */
     public function set($key, $value)
     {
@@ -109,8 +109,8 @@ class OrderSearchCriteria
     /**
      * Fill the criteria.
      *
-     * @param array $values
-     * @return self
+     * @param  array  $values
+     * @return $this
      */
     public function fill($values = [])
     {
@@ -124,7 +124,7 @@ class OrderSearchCriteria
     /**
      * Get all the criteria params.
      *
-     * @return void
+     * @return array
      */
     public function toParams()
     {
@@ -134,7 +134,7 @@ class OrderSearchCriteria
     /**
      * Get the result from our defined criteria.
      *
-     * @return string
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function get()
     {

--- a/src/Core/Orders/Services/OrderLineService.php
+++ b/src/Core/Orders/Services/OrderLineService.php
@@ -10,10 +10,19 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 
 class OrderLineService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Orders\Services\OrderService
+     */
     protected $orders;
 
+    /**
+     * @var \GetCandy\Api\Core\Products\Services\ProductVariantService
+     */
     protected $variants;
 
+    /**
+     * @var \GetCandy\Api\Core\Pricing\PriceCalculatorInterface
+     */
     protected $calculator;
 
     public function __construct(
@@ -30,9 +39,10 @@ class OrderLineService extends BaseService
     /**
      * Add a manual order line.
      *
-     * @param string $orderId
-     * @param array $data
-     * @return Order
+     * @param  string  $orderId
+     * @param  array  $data
+     * @param  bool  $manual
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function store($orderId, $data = [], $manual = true)
     {
@@ -81,8 +91,8 @@ class OrderLineService extends BaseService
     /**
      * Delete an order line.
      *
-     * @param string $lineId
-     * @return Order
+     * @param  string  $lineId
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function delete($lineId)
     {

--- a/src/Core/Orders/Services/OrderService.php
+++ b/src/Core/Orders/Services/OrderService.php
@@ -29,33 +29,33 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * The basket service.
      *
-     * @var BasketService
+     * @var \GetCandy\Api\Core\Baskets\Services\BasketService
      */
     protected $baskets;
 
     /**
-     * @var Basket
+     * @var \GetCandy\Api\Core\Orders\Models\Order
      */
     protected $model;
 
     /**
      * The payments service.
      *
-     * @var PaymentService
+     * @var \GetCandy\Api\Core\Payments\Services\PaymentService
      */
     protected $payments;
 
     /**
      * The price calculator instance.
      *
-     * @var CurrencyConverterInterface
+     * @var \GetCandy\Api\Core\Currencies\Interfaces\CurrencyConverterInterface
      */
     protected $currencies;
 
     /**
      * The price calculator instance.
      *
-     * @var PriceCalculatorInterface
+     * @var \GetCandy\Api\Core\Pricing\PriceCalculatorInterface
      */
     protected $calculator;
 
@@ -79,9 +79,11 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Stores an order.
      *
-     * @param string $basketId
-     *
-     * @return Order
+     * @param  string  $basketId
+     * @param  null|\Illuminate\Foundation\Auth\User  $user
+     * @return \GetCandy\Api\Core\Orders\Models\Order
+     * 
+     * @throws \GetCandy\Api\Core\Orders\Exceptions\BasketHasPlacedOrderException
      */
     public function store($basketId, $user = null)
     {
@@ -143,11 +145,10 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Adds a shipping line to an order.
      *
-     * @param string $orderId
-     * @param string $shippingPriceId
-     * @param string $preference
-     *
-     * @return Order
+     * @param  string  $orderId
+     * @param  string  $shippingPriceId
+     * @param  null|string  $preference
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function addShippingLine($orderId, $shippingPriceId, $preference = null)
     {
@@ -205,11 +206,15 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Bulk update an order.
      *
-     * @param array $orderIds
-     * @param string $field
-     * @param string $value
-     * @throws \Illuminate\Database\QueryException
+     * @param  array  $orderIds
+     * @param  string  $field
+     * @param  string  $value
+     * @param  bool  $sendEmails
+     * @param  array  $data
      * @return void
+     * 
+     * @throws \Illuminate\Database\QueryException
+     * @throws \InvalidArgumentException
      */
     public function bulkUpdate($orderIds, $field, $value, $sendEmails = true, $data = [])
     {
@@ -264,10 +269,11 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Update an order.
      *
-     * @param string $orderId
-     * @param array $data
-     *
-     * @return Order
+     * @param  string  $orderId
+     * @param  array  $data
+     * @param  bool  $sendEmails
+     * @param  array  $emailContent
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function update($orderId, array $data, $sendEmails = true, $emailContent = [])
     {
@@ -313,10 +319,10 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Set the delivery details.
      *
-     * @param string $id
-     * @param array $data
-     *
-     * @return Order
+     * @param  string  $id
+     * @param  array  $data
+     * @param  null|\Illuminate\Foundation\Auth\User  $user
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function setShipping($id, array $data, $user = null)
     {
@@ -344,8 +350,8 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Recalculates an orders totals.
      *
-     * @param Order $order
-     * @return void
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function recalculate($order)
     {
@@ -401,10 +407,10 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Set the delivery details.
      *
-     * @param string $id
-     * @param array $data
-     *
-     * @return Order
+     * @param  string  $id
+     * @param  array  $data
+     * @param  null|\Illuminate\Foundation\Auth\User  $user
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function setBilling($id, array $data, $user = null)
     {
@@ -419,11 +425,11 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Adds an address for an order.
      *
-     * @param string $id
-     * @param array $data
-     * @param string $type
-     *
-     * @return Order
+     * @param  string  $id
+     * @param  array  $data
+     * @param  string  $type
+     * @param  null|\Illuminate\Foundation\Auth\User  $user
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function addAddress($id, $data, $type, $user = null)
     {
@@ -472,10 +478,9 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Sets the delivery price on an.
      *
-     * @param string $orderId
-     * @param string $priceId
-     *
-     * @return Order
+     * @param  string  $orderId
+     * @param  string  $priceId
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function setDeliveryPrice($orderId, $priceId)
     {
@@ -485,10 +490,9 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Sets the fields for contact info on the order.
      *
-     * @param string $order
-     * @param array $fields
-     * @param string $prefix
-     *
+     * @param  string  $order
+     * @param  array  $fields
+     * @param  string  $prefix
      * @return void
      */
     protected function setFields($order, $fields, $prefix)
@@ -512,9 +516,8 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Expires an order.
      *
-     * @param string $orderId
-     *
-     * @return void
+     * @param  string  $orderId
+     * @return bool
      */
     public function expire($orderId)
     {
@@ -539,6 +542,8 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Get the next invoice reference.
      *
+     * @param  null|string  $year
+     * @param  null|string  $year
      * @return string
      */
     protected function getNextInvoiceReference($year = null, $month = null)
@@ -576,11 +581,11 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Syncs a given basket with its order.
      *
-     * @param Order $order
-     * @param Basket $basket
-     * @deprecated 0.3.35
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      *
-     * @return Order
+     * @deprecated 0.3.35
      */
     public function syncWithBasket(Order $order, Basket $basket)
     {
@@ -593,9 +598,8 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Maps the order lines from a basket.
      *
-     * @param Basket $basket
-     *
-     * @return void
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @return array
      */
     protected function mapOrderLines($basket)
     {
@@ -622,8 +626,7 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Determines whether an active order exists with this id.
      *
-     * @param string $orderId
-     *
+     * @param  string  $orderId
      * @return bool
      */
     public function isActive($orderId)
@@ -636,8 +639,7 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Checks whether an order is processable.
      *
-     * @param Order $order
-     *
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
      * @return bool
      */
     protected function isProcessable(Order $order)
@@ -652,7 +654,7 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Process an order for payment.
      *
-     * @param array $data
+     * @param  array  $data
      * @return mixed
      */
     public function process(array $data)
@@ -690,9 +692,10 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Handles the response from an order being processed.
      *
-     * @param Transaction $transaction
-     * @param Order $order
-     * @return void
+     * @param  \GetCandy\Api\Core\Payments\Models\Transaction  $transaction
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  mixed $type
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     protected function handleProcessResponse($transaction, $order, $type = null)
     {
@@ -731,11 +734,11 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Process a 3DSecured transaction.
      *
-     * @param Order $order
-     * @param string $transactionId
-     * @param string $paRes
-     * @param string $type
-     * @return Order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  string  $transactionId
+     * @param  string  $paRes
+     * @param  string  $type
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function processThreeDSecure($order, $transactionId, $paRes, $type = null)
     {
@@ -757,10 +760,9 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Set the contact details on an order.
      *
-     * @param string $orderId
-     * @param array $data
-     *
-     * @return Order
+     * @param  string  $orderId
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Orders\Models\Order
      */
     public function setContact($orderId, array $data)
     {
@@ -822,8 +824,8 @@ class OrderService extends BaseService implements OrderServiceInterface
     /**
      * Process discount lines for an order.
      *
-     * @param Basket $basket
-     * @param Order $order
+     * @param  \GetCandy\Api\Core\Baskets\Models\Basket  $basket
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
      * @return void
      */
     protected function processDiscountLines(Basket $basket, Order $order)

--- a/src/Core/Pages/Models/Page.php
+++ b/src/Core/Pages/Models/Page.php
@@ -9,7 +9,13 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Page extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
+    
     /**
      * The attributes that are mass assignable.
      *

--- a/src/Core/Pages/Services/PageService.php
+++ b/src/Core/Pages/Services/PageService.php
@@ -16,15 +16,17 @@ class PageService extends BaseService
 
     /**
      * Creates a page.
-     * @param  array                $data
-     * @param  string|Language      $languageCode
-     * @param  string|Layout        $layout
-     * @param  string|Channel       $channel
-     * @param  string               $type
-     * @param  Model|null           $relation
-     * @throws InvalidLanguageException
-     * @throws Symfony\Component\HttpKernel\Exception\HttpException
-     * @return Page
+     * 
+     * @param  array  $data
+     * @param  string|\GetCandy\Api\Core\Languages\Models\Language  $languageCode
+     * @param  string|\GetCandy\Api\Core\Layouts\Models\Layout  $layout
+     * @param  string|\GetCandy\Api\Core\Channels\Models\Channel  $channel
+     * @param  string  $type
+     * @param  null|\Illuminate\Database\Eloquent\Model  $relation
+     * @return \GetCandy\Api\Core\Pages\Models\Page
+     * 
+     * @throws \GetCandy\Exceptions\InvalidLanguageException
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function create(array $data, $languageCode, $layout, $channel, $type = null, Model $relation = null)
     {
@@ -90,11 +92,13 @@ class PageService extends BaseService
 
     /**
      * Finds a page based on it's channel, language and slug.
-     * @param  string $channel
-     * @param  string $lang
-     * @param  string $slug
-     * @throws Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return mixed
+     *
+     * @param  string  $channel
+     * @param  string  $lang
+     * @param  null|string  $slug
+     * @return \GetCandy\Api\Core\Pages\Models\Page
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function findPage($channel, $lang, $slug = null)
     {
@@ -129,7 +133,8 @@ class PageService extends BaseService
 
     /**
      * Gets a unique slug for a page.
-     * @param  string $slug
+     *
+     * @param  string  $slug
      * @return string
      */
     protected function getUniqueSlug($slug)

--- a/src/Core/Payments/Events/PaymentAttemptedEvent.php
+++ b/src/Core/Payments/Events/PaymentAttemptedEvent.php
@@ -27,7 +27,7 @@ class PaymentAttemptedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Payments/Events/PaymentFailedEvent.php
+++ b/src/Core/Payments/Events/PaymentFailedEvent.php
@@ -27,7 +27,7 @@ class PaymentFailedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Payments/Events/ThreeDSecureAttemptEvent.php
+++ b/src/Core/Payments/Events/ThreeDSecureAttemptEvent.php
@@ -27,7 +27,7 @@ class ThreeDSecureAttemptEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Payments/Events/TransactionFetchedEvent.php
+++ b/src/Core/Payments/Events/TransactionFetchedEvent.php
@@ -27,7 +27,7 @@ class TransactionFetchedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Payments/Models/PaymentType.php
+++ b/src/Core/Payments/Models/PaymentType.php
@@ -10,6 +10,11 @@ class PaymentType extends BaseModel
 {
     use HasCustomerGroups;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public function customerGroups()

--- a/src/Core/Payments/Models/ReusablePayment.php
+++ b/src/Core/Payments/Models/ReusablePayment.php
@@ -8,5 +8,10 @@ class ReusablePayment extends BaseModel
 {
     protected $dates = ['expires_at'];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'product';
 }

--- a/src/Core/Payments/Models/Transaction.php
+++ b/src/Core/Payments/Models/Transaction.php
@@ -12,8 +12,18 @@ class Transaction extends BaseModel
 
     protected static $logAttributes = ['transaction_id'];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'order';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'merchant', 'success', 'status',
     ];

--- a/src/Core/Payments/PaymentManager.php
+++ b/src/Core/Payments/PaymentManager.php
@@ -24,7 +24,7 @@ class PaymentManager extends Manager implements PaymentContract
     /**
      * Create the PayPal driver.
      *
-     * @return PayPal
+     * @return \GetCandy\Api\Core\Payments\Providers\PayPal
      */
     public function createPaypalDriver()
     {
@@ -36,7 +36,7 @@ class PaymentManager extends Manager implements PaymentContract
     /**
      * Create the sagepay driver.
      *
-     * @return SagePay
+     * @return \GetCandy\Api\Core\Payments\Providers\SagePay
      */
     public function createSagepayDriver()
     {
@@ -48,7 +48,7 @@ class PaymentManager extends Manager implements PaymentContract
     /**
      * Create the sagepay driver.
      *
-     * @return SagePay
+     * @return \GetCandy\Api\Core\Payments\Providers\Braintree
      */
     public function createBraintreeDriver()
     {
@@ -60,7 +60,7 @@ class PaymentManager extends Manager implements PaymentContract
     /**
      * Create the offline driver.
      *
-     * @return Offline
+     * @return \GetCandy\Api\Core\Payments\Providers\Offline
      */
     public function createOfflineDriver()
     {
@@ -73,8 +73,7 @@ class PaymentManager extends Manager implements PaymentContract
      * Build a layout provider instance.
      *
      * @param  string  $provider
-     * @param  array  $config
-     * @return \Laravel\Socialite\Two\AbstractProvider
+     * @return \GetCandy\Api\Core\Payments\Providers\AbstractProvider
      */
     public function buildProvider($provider)
     {
@@ -84,9 +83,9 @@ class PaymentManager extends Manager implements PaymentContract
     /**
      * Get the default driver name.
      *
-     * @throws \InvalidArgumentException
-     *
      * @return string
+     * 
+     * @throws \InvalidArgumentException
      */
     public function getDefaultDriver()
     {

--- a/src/Core/Payments/PaymentResponse.php
+++ b/src/Core/Payments/PaymentResponse.php
@@ -16,7 +16,7 @@ class PaymentResponse
     /**
      * The response message.
      *
-     * @var string
+     * @var string|null
      */
     public $message = null;
 
@@ -30,7 +30,7 @@ class PaymentResponse
     /**
      * The transaction object.
      *
-     * @var Transaction
+     * @var null|\GetCandy\Api\Core\Payments\Models\Transaction
      */
     protected $transaction = null;
 
@@ -44,8 +44,8 @@ class PaymentResponse
     /**
      * Set the transaction.
      *
-     * @param Transaction $transaction
-     * @return PaymentResponse
+     * @param  \GetCandy\Api\Core\Payments\Models\Transaction  $transaction
+     * @return $this
      */
     public function transaction($transaction)
     {
@@ -57,7 +57,7 @@ class PaymentResponse
     /**
      * Get the transaction object.
      *
-     * @return Transaction
+     * @return \GetCandy\Api\Core\Payments\Models\Transaction
      */
     public function getTransaction()
     {

--- a/src/Core/Payments/Providers/AbstractProvider.php
+++ b/src/Core/Payments/Providers/AbstractProvider.php
@@ -11,7 +11,7 @@ abstract class AbstractProvider
     /**
      * The order to process.
      *
-     * @var Order
+     * @var \GetCandy\Api\Core\Orders\Models\Order
      */
     protected $order;
 
@@ -25,15 +25,15 @@ abstract class AbstractProvider
     /**
      * The payment token.
      *
-     * @var string
+     * @var null|string
      */
     protected $token = null;
 
     /**
      * Set the order.
      *
-     * @param Order $order
-     * @return AbstractProvider
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return $this
      */
     public function order(Order $order)
     {
@@ -45,8 +45,8 @@ abstract class AbstractProvider
     /**
      * Set additional fields.
      *
-     * @param array $fields
-     * @return AbstractProvider
+     * @param  array  $fields
+     * @return $this
      */
     public function fields(array $fields)
     {
@@ -58,8 +58,8 @@ abstract class AbstractProvider
     /**
      * Set the payment token.
      *
-     * @param string $token
-     * @return AbstractToken
+     * @param  string  $token
+     * @return $this
      */
     public function token($token)
     {
@@ -71,21 +71,20 @@ abstract class AbstractProvider
     /**
      * Validate the payment token.
      *
-     * @param string $token
+     * @param  string  $token
      * @return void
      */
     abstract public function validate($token);
 
     /**
      * Gets the name of the provider.
+     * 
      * @return string
      */
     abstract public function getName();
 
     /**
      * Create a charge for a payment token.
-     *
-     * @param string $token
      *
      * @return void
      */
@@ -94,9 +93,9 @@ abstract class AbstractProvider
     /**
      * Refund a transaction.
      *
-     * @param string $token
-     * @param mixed $amount
-     *
+     * @param  string  $token
+     * @param  mixed  $amount
+     * @param  mixed  $description
      * @return void
      */
     abstract public function refund($token, $amount, $description);

--- a/src/Core/Payments/Providers/Braintree.php
+++ b/src/Core/Payments/Providers/Braintree.php
@@ -14,6 +14,7 @@ class Braintree extends AbstractProvider
 
     /**
      * The Braintree api gateway.
+     * 
      * @var Braintree_Gateway
      */
     protected $gateway;
@@ -136,8 +137,8 @@ class Braintree extends AbstractProvider
     /**
      * Create a failed transaction.
      *
-     * @param array $errors
-     * @return Transaction
+     * @param  array  $result
+     * @return \GetCandy\Api\Core\Payments\Models\Transaction
      */
     protected function createFailedTransaction($result)
     {

--- a/src/Core/Payments/Providers/Offline.php
+++ b/src/Core/Payments/Providers/Offline.php
@@ -6,6 +6,9 @@ use GetCandy\Api\Core\Payments\PaymentResponse;
 
 class Offline extends AbstractProvider
 {
+    /**
+     * @var string
+     */
     protected $name = 'Offline';
 
     public function getName()

--- a/src/Core/Payments/Providers/PayPal.php
+++ b/src/Core/Payments/Providers/PayPal.php
@@ -14,21 +14,21 @@ class PayPal extends AbstractProvider
     /**
      * The Guzzle client.
      *
-     * @var Client
+     * @var \GuzzleHttp\Client
      */
     protected $client;
 
     /**
      * The environment context.
      *
-     * @var ApiContext
+     * @var \PayPal\Rest\ApiContext
      */
     protected $context;
 
     /**
      * PayPal payment details.
      *
-     * @var Payment
+     * @var \PayPal\Api\Payment
      */
     protected $details;
 
@@ -57,7 +57,7 @@ class PayPal extends AbstractProvider
     /**
      * Checks whether the token is valid.
      *
-     * @param string $token
+     * @param  string  $token
      * @return bool
      */
     public function validate($token)
@@ -99,9 +99,7 @@ class PayPal extends AbstractProvider
     /**
      * Create a successful transaction.
      *
-     * @param [type] $content
-     * @param [type] $order
-     * @return void
+     * @return \Illuminate\Support\Collection
      */
     protected function getTransactions()
     {

--- a/src/Core/Payments/Providers/SagePay.php
+++ b/src/Core/Payments/Providers/SagePay.php
@@ -315,8 +315,8 @@ class SagePay extends AbstractProvider
     /**
      * Create a failed transaction.
      *
-     * @param array $errors
-     * @return Transaction
+     * @param  array  $errors
+     * @return \GetCandy\Api\Core\Payments\Models\Transaction
      */
     protected function createFailedTransaction($errors, $amount = null, $notes = null)
     {
@@ -345,7 +345,7 @@ class SagePay extends AbstractProvider
     /**
      * Get the client token for authentication.
      *
-     * @return void
+     * @return string|null
      */
     public function getClientToken()
     {
@@ -376,7 +376,7 @@ class SagePay extends AbstractProvider
     /**
      * Get the token expiry.
      *
-     * @return Carbon\Carbon
+     * @return \Carbon\Carbon
      */
     public function getTokenExpiry()
     {

--- a/src/Core/Payments/Services/PaymentService.php
+++ b/src/Core/Payments/Services/PaymentService.php
@@ -22,7 +22,7 @@ class PaymentService extends BaseService
     /**
      * Payment Manager.
      *
-     * @var PaymentContract
+     * @var \GetCandy\Api\Core\Payments\PaymentContract
      */
     protected $manager;
 
@@ -35,7 +35,7 @@ class PaymentService extends BaseService
     /**
      * Gets the payment provider class.
      *
-     * @return void
+     * @return mixed
      */
     public function getProvider()
     {
@@ -60,7 +60,7 @@ class PaymentService extends BaseService
     /**
      * Set the provider.
      *
-     * @param string $provider
+     * @param  string  $provider
      * @return mixed
      */
     public function setProvider($provider)
@@ -73,11 +73,13 @@ class PaymentService extends BaseService
     /**
      * Charge the order.
      *
-     * @param Order $order
-     * @param string $token
-     * @param string $type
-     *
-     * @return bool
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  string|null  $token
+     * @param  string|null  $type
+     * @param  array  $data
+     * @return mixed
+     * 
+     * @throws \GetCandy\Api\Core\Orders\Exceptions\OrderAlreadyProcessedException
      */
     public function charge(Order $order, $token = null, $type = null, $data = [])
     {
@@ -95,11 +97,15 @@ class PaymentService extends BaseService
     /**
      * Process an order for payment.
      *
-     * @param Order $order
-     * @param string $token
-     * @param mixed $type
-     * @param array $fields
-     * @return void
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  string  $token
+     * @param  mixed  $type
+     * @param  array  $fields
+     * @return mixed
+     * 
+     * @throws \GetCandy\Api\Core\Orders\Exceptions\OrderAlreadyProcessedException
+     * @throws \GetCandy\Api\Core\Payments\Exceptions\InvalidPaymentTokenException
+     * @throws \GetCandy\Api\Core\Payments\Exceptions\ThreeDSecureRequiredException
      */
     public function process($order, $token, $type = null, $fields = [])
     {
@@ -131,9 +137,10 @@ class PaymentService extends BaseService
     /**
      * Refund a sale.
      *
-     * @param string $token
-     *
-     * @return void
+     * @param  string  $id
+     * @param  int  $amount
+     * @param  string|null $notes
+     * @return mixed
      */
     public function refund($id, int $amount, $notes = null)
     {
@@ -170,9 +177,11 @@ class PaymentService extends BaseService
     /**
      * Validate a 3DSecure transaction.
      *
-     * @param string $transactionId The transaction ID from the provider
-     * @param string $paRes The encoded response from the 3DSecure form
-     * @return Transaction
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @param  string  $transactionId - The transaction ID from the provider
+     * @param  string  $paRes - The encoded response from the 3DSecure form
+     * @param  mixed  $type
+     * @return \GetCandy\Api\Core\Payments\Models\Transaction
      */
     public function validateThreeD($order, $transactionId, $paRes, $type = null)
     {
@@ -189,9 +198,8 @@ class PaymentService extends BaseService
     /**
      * Creates a transaction.
      *
-     * @param array $data
-     *
-     * @return Transaction
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Payments\Models\Transaction
      */
     protected function createTransaction(array $data)
     {
@@ -211,9 +219,8 @@ class PaymentService extends BaseService
     /**
      * Voids a transaction.
      *
-     * @param string $transactionId
-     *
-     * @return Transaction
+     * @param  string  $transactionId
+     * @return \GetCandy\Api\Core\Payments\Models\Transaction
      */
     public function void($transactionId)
     {

--- a/src/Core/Pricing/PriceCalculator.php
+++ b/src/Core/Pricing/PriceCalculator.php
@@ -10,14 +10,14 @@ class PriceCalculator implements PriceCalculatorInterface
     /**
      * The currency converter instance.
      *
-     * @var CurrencyConverterInterface
+     * @var \GetCandy\Api\Core\Currencies\Interfaces\CurrencyConverterInterface
      */
     protected $converter;
 
     /**
      * The tax calculator instance.
      *
-     * @var TaxCalculatorInterface
+     * @var \GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface
      */
     protected $taxes;
 

--- a/src/Core/Products/Drafting/ProductDrafter.php
+++ b/src/Core/Products/Drafting/ProductDrafter.php
@@ -69,8 +69,8 @@ class ProductDrafter implements DrafterInterface
     /**
      * Duplicate a product.
      *
-     * @param Collection $data
-     * @return Product
+     * @param  \Illuminate\Database\Eloquent\Model  $product
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function firstOrCreate(Model $product)
     {
@@ -133,7 +133,8 @@ class ProductDrafter implements DrafterInterface
     /**
      * Process the assets for a duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $oldProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processAssets($oldProduct, &$newProduct)
@@ -152,7 +153,8 @@ class ProductDrafter implements DrafterInterface
     /**
      * Process the duplicated product categories.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $oldProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processCategories($oldProduct, &$newProduct)
@@ -166,7 +168,8 @@ class ProductDrafter implements DrafterInterface
     /**
      * Process the customer groups for the duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $oldProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processCustomerGroups($oldProduct, &$newProduct)
@@ -191,7 +194,8 @@ class ProductDrafter implements DrafterInterface
     /**
      * Process channels for a duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $oldProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processChannels($oldProduct, &$newProduct)

--- a/src/Core/Products/Events/ProductCreatedEvent.php
+++ b/src/Core/Products/Events/ProductCreatedEvent.php
@@ -13,6 +13,9 @@ class ProductCreatedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @var \GetCandy\Api\Core\Products\Models\Product
+     */
     protected $product;
 
     /**
@@ -33,7 +36,7 @@ class ProductCreatedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Products/Events/ProductSavedEvent.php
+++ b/src/Core/Products/Events/ProductSavedEvent.php
@@ -13,11 +13,15 @@ class ProductSavedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @var \GetCandy\Api\Core\Products\Models\Product
+     */
     protected $product;
 
     /**
      * Create a new event instance.
      *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return void
      */
     public function __construct(Product $product)
@@ -33,7 +37,7 @@ class ProductSavedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Products/Events/ProductViewedEvent.php
+++ b/src/Core/Products/Events/ProductViewedEvent.php
@@ -13,11 +13,15 @@ class ProductViewedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @var \GetCandy\Api\Core\Products\Models\Product
+     */
     protected $product;
 
     /**
      * Create a new event instance.
      *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return void
      */
     public function __construct(Product $product)
@@ -33,7 +37,7 @@ class ProductViewedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Products/Factories/ProductDuplicateFactory.php
+++ b/src/Core/Products/Factories/ProductDuplicateFactory.php
@@ -13,9 +13,7 @@ use Storage;
 class ProductDuplicateFactory implements ProductInterface
 {
     /**
-     * The product.
-     *
-     * @var Product
+     * @var \GetCandy\Api\Core\Products\Models\Product
      */
     protected $product;
 
@@ -29,8 +27,8 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Duplicate a product.
      *
-     * @param Collection $data
-     * @return Product
+     * @param  \Illuminate\Support\Collection  $data
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function duplicate(Collection $data)
     {
@@ -70,7 +68,7 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Process the assets for a duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processAssets($newProduct)
@@ -123,7 +121,7 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Process the duplicated product categories.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processCategories($newProduct)
@@ -137,7 +135,7 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Process the customer groups for the duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processCustomerGroups($newProduct)
@@ -160,7 +158,7 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Process channels for a duplicated product.
      *
-     * @param Product $newProduct
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
      * @return void
      */
     protected function processChannels($newProduct)
@@ -183,9 +181,9 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Process the variants for duplication.
      *
-     * @param Product $newProduct
-     * @param Collection $currentVariants
-     * @param Collection $data
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
+     * @param  \Illuminate\Support\Collection  $currentVariants
+     * @param  \Illuminate\Support\Collection  $data
      * @return void
      */
     protected function processVariants($newProduct, $currentVariants, $data)
@@ -205,9 +203,9 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Process the routes for duplication.
      *
-     * @param Product $newProduct
-     * @param Collection $currentRoutes
-     * @param Collection $data
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $newProduct
+     * @param  \Illuminate\Support\Collection  $currentRoutes
+     * @param  \Illuminate\Support\Collection  $data
      * @return void
      */
     protected function processRoutes($newProduct, $currentRoutes, $data)
@@ -230,9 +228,9 @@ class ProductDuplicateFactory implements ProductInterface
     /**
      * Get the variant to copy.
      *
-     * @param array $variants
-     * @param string $sku
-     * @return ProductVariant
+     * @param  \Illuminate\Support\Collection  $variants
+     * @param  string  $sku
+     * @return \GetCandy\Api\Core\Products\Models\ProductVariant
      */
     protected function getVariantToCopy($variants, $sku)
     {

--- a/src/Core/Products/Factories/ProductFactory.php
+++ b/src/Core/Products/Factories/ProductFactory.php
@@ -10,16 +10,12 @@ use Illuminate\Support\Collection;
 class ProductFactory implements ProductInterface
 {
     /**
-     * The product.
-     *
-     * @var Product
+     * @var \GetCandy\Api\Core\Products\Models\Product
      */
     protected $product;
 
     /**
-     * The variant factory.
-     *
-     * @var ProductVariantInterface
+     * @var \GetCandy\Api\Core\Products\Interfaces\ProductVariantInterface
      */
     protected $variantFactory;
 
@@ -38,7 +34,7 @@ class ProductFactory implements ProductInterface
     /**
      * Get the processed product.
      *
-     * @return void
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function get()
     {
@@ -61,8 +57,8 @@ class ProductFactory implements ProductInterface
     /**
      * Process a collection of products.
      *
-     * @param Collection $products
-     * @return Collection
+     * @param  \Illuminate\Support\Collection  $products
+     * @return \Illuminate\Support\Collection
      */
     public function collection(Collection $products)
     {

--- a/src/Core/Products/Factories/ProductVariantFactory.php
+++ b/src/Core/Products/Factories/ProductVariantFactory.php
@@ -10,9 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 class ProductVariantFactory extends AbstractFactory implements ProductVariantInterface
 {
     /**
-     * The variant.
-     *
-     * @var ProductVariant
+     * @var \GetCandy\Api\Core\Products\Models\ProductVariant
      */
     protected $variant;
 
@@ -65,8 +63,9 @@ class ProductVariantFactory extends AbstractFactory implements ProductVariantInt
     /**
      * Get tiered price for variant.
      *
-     * @param int $quantity
-     * @param mixed $user
+     * @param  int  $qty
+     * @param  int  $factor
+     * @param  null|\Illuminate\Foundation\Auth\User  $user
      * @return \Illuminate\Support\Collection
      */
     public function getTieredPrice($qty = 1, $factor = 1, $user = null)
@@ -105,7 +104,8 @@ class ProductVariantFactory extends AbstractFactory implements ProductVariantInt
     /**
      * Get the variant price for a user.
      *
-     * @param mixed $user
+     * @param  int  $qty
+     * @param  null|\Illuminate\Foundation\Auth\User  $user
      * @return \Illuminate\Support\Collection
      */
     public function getVariantPrice($qty = 1, $user = null)

--- a/src/Core/Products/Listeners/AddToIndexListener.php
+++ b/src/Core/Products/Listeners/AddToIndexListener.php
@@ -19,7 +19,7 @@ class AddToIndexListener
     /**
      * Handle the event.
      *
-     * @param  ProductCreatedEvent  $event
+     * @param  \GetCandy\Api\Core\Products\Events\ProductCreatedEvent  $event
      * @return void
      */
     public function handle(ProductCreatedEvent $event)

--- a/src/Core/Products/Models/Product.php
+++ b/src/Core/Products/Models/Product.php
@@ -36,8 +36,14 @@ class Product extends BaseModel
         Versionable,
         Recyclable;
 
+    /**
+     * @var string
+     */
     protected $settings = 'products';
 
+    /**
+     * @var int
+     */
     protected $keepOldVersions = 10;
 
     /**
@@ -54,10 +60,19 @@ class Product extends BaseModel
      */
     public $max_price = 0;
 
+    /**
+     * @var int
+     */
     public $min_price_tax = 0;
 
+    /**
+     * @var int
+     */
     public $max_price_tax = 0;
 
+    /**
+     * @var array
+     */
     protected $dates = ['deleted_at'];
 
     /**
@@ -68,12 +83,15 @@ class Product extends BaseModel
     public $resource = ProductResource::class;
 
     /**
+     * @var string
+     * 
      * @deprecated 0.9.0
      */
     public $transformer = ProductTransformer::class;
 
     /**
-     * The Hashid Channel for encoding the id.
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'product';
@@ -105,7 +123,8 @@ class Product extends BaseModel
      *         ]
      *     ]
      * ].
-     * @param array $value [description]
+     * @param  array  $value
+     * @return void
      */
     public function setOptionDataAttribute($value)
     {
@@ -141,8 +160,9 @@ class Product extends BaseModel
     }
 
     /**
-     * Get the attributes associated to the product.
-     * @return Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * Get the collections associated to the product.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function collections()
     {
@@ -151,7 +171,8 @@ class Product extends BaseModel
 
     /**
      * Get the related family.
-     * @return Illuminate\Database\Eloquent\Relations\BelongsTo
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function family()
     {
@@ -160,7 +181,8 @@ class Product extends BaseModel
 
     /**
      * Get the products page.
-     * @return Illuminate\Database\Eloquent\Relations\MorphOne
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
     public function page()
     {

--- a/src/Core/Products/Models/ProductAssociation.php
+++ b/src/Core/Products/Models/ProductAssociation.php
@@ -8,11 +8,17 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 class ProductAssociation extends BaseModel
 {
     /**
-     * The Hashid Channel for encoding the id.
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'product';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'group_id',
         'association_id',
@@ -20,8 +26,9 @@ class ProductAssociation extends BaseModel
     ];
 
     /**
-     * Get the attributes associated to the product.
-     * @return Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * Get the parent product associated.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function parent()
     {

--- a/src/Core/Products/Models/ProductCustomerPrice.php
+++ b/src/Core/Products/Models/ProductCustomerPrice.php
@@ -9,6 +9,11 @@ use GetCandy\Api\Core\Taxes\Models\Tax;
 
 class ProductCustomerPrice extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'customer_group_id',
         'tax_id',
@@ -28,7 +33,8 @@ class ProductCustomerPrice extends BaseModel
     }
 
     /**
-     * The Hashid Channel for encoding the id.
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'product_family';

--- a/src/Core/Products/Models/ProductFamily.php
+++ b/src/Core/Products/Models/ProductFamily.php
@@ -8,7 +8,8 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 class ProductFamily extends BaseModel
 {
     /**
-     * The Hashid Channel for encoding the id.
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'product_family';
@@ -21,7 +22,9 @@ class ProductFamily extends BaseModel
     }
 
     /**
-     * Get all of the tags for the post.
+     * Get all of the attributes for the product family.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function attributes()
     {
@@ -31,7 +34,7 @@ class ProductFamily extends BaseModel
     /**
      * Scope a query to only include the default record.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeDefault($query)

--- a/src/Core/Products/Models/ProductPricingTier.php
+++ b/src/Core/Products/Models/ProductPricingTier.php
@@ -9,6 +9,11 @@ use GetCandy\Api\Core\Scopes\ProductPricingScope;
 
 class ProductPricingTier extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'customer_group_id',
         'product_variant_id',
@@ -45,7 +50,7 @@ class ProductPricingTier extends BaseModel
     }
 
     /**
-     * Get the total cost attribute.
+     * Get the total tax attribute.
      *
      * @return int
      */
@@ -55,7 +60,7 @@ class ProductPricingTier extends BaseModel
     }
 
     /**
-     * Get the total cost attribute.
+     * Get the limit tax attribute.
      *
      * @return int
      */
@@ -65,7 +70,8 @@ class ProductPricingTier extends BaseModel
     }
 
     /**
-     * The Hashid Channel for encoding the id.
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'product_family';

--- a/src/Core/Products/Models/ProductRecommendation.php
+++ b/src/Core/Products/Models/ProductRecommendation.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class ProductRecommendation extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = ['product_id'];
 
     public $timestamps = false;

--- a/src/Core/Products/Models/ProductVariant.php
+++ b/src/Core/Products/Models/ProductVariant.php
@@ -12,12 +12,19 @@ use GetCandy\Api\Core\Traits\Lockable;
 class ProductVariant extends BaseModel
 {
     use HasAttributes, Lockable;
+
     /**
-     * The Hashid Channel for encoding the id.
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'product';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'options',
         'price',
@@ -37,7 +44,7 @@ class ProductVariant extends BaseModel
     /**
      * Return the product relation.
      *
-     * @return BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function product()
     {
@@ -47,7 +54,7 @@ class ProductVariant extends BaseModel
     /**
      * Return the product relation.
      *
-     * @return BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function availableProduct()
     {
@@ -57,7 +64,7 @@ class ProductVariant extends BaseModel
     /**
      * Return the basket lines.
      *
-     * @return HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function basketLines()
     {

--- a/src/Core/Products/Observers/ProductObserver.php
+++ b/src/Core/Products/Observers/ProductObserver.php
@@ -8,9 +8,7 @@ use GetCandy\Api\Core\Products\Models\Product;
 class ProductObserver
 {
     /**
-     * The asset server.
-     *
-     * @var AssetService
+     * @var \GetCandy\Api\Core\Assets\Services\AssetService
      */
     protected $assets;
 
@@ -22,7 +20,7 @@ class ProductObserver
     /**
      * Handle the User "deleted" event.
      *
-     * @param  \App\User  $user
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return void
      */
     public function deleted(Product $product)

--- a/src/Core/Products/Services/ProductAssociationService.php
+++ b/src/Core/Products/Services/ProductAssociationService.php
@@ -8,6 +8,9 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 
 class ProductAssociationService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Products\Models\ProductAssociation
+     */
     protected $associations;
 
     public function __construct()
@@ -18,9 +21,10 @@ class ProductAssociationService extends BaseService
 
     /**
      * Stores a product association.
-     * @param  string $product
-     * @param  array $data
-     * @return mixed
+     * 
+     * @param  string  $product
+     * @param  array  $data
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function store($product, $data)
     {
@@ -43,8 +47,9 @@ class ProductAssociationService extends BaseService
 
     /**
      * Destroys product association/s.
-     * @param  string $product
-     * @param  array/string $association
+     * 
+     * @param  string  $product
+     * @param  array|string  $association
      * @return bool
      */
     public function destroy($product, $association)

--- a/src/Core/Products/Services/ProductChannelService.php
+++ b/src/Core/Products/Services/ProductChannelService.php
@@ -8,6 +8,9 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 
 class ProductChannelService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Channels\Services\ChannelService
+     */
     protected $channelService;
 
     public function __construct(ChannelService $channels)
@@ -18,9 +21,10 @@ class ProductChannelService extends BaseService
 
     /**
      * Stores a product association.
-     * @param  string $product
-     * @param  array $data
-     * @return mixed
+     * 
+     * @param  string  $product
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function store($product, $channels)
     {
@@ -35,8 +39,9 @@ class ProductChannelService extends BaseService
 
     /**
      * Destroys product customer groups.
-     * @param  string $product
-     * @return bool
+     *
+     * @param  string  $product
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function destroy($product)
     {

--- a/src/Core/Products/Services/ProductCustomerGroupService.php
+++ b/src/Core/Products/Services/ProductCustomerGroupService.php
@@ -8,6 +8,9 @@ use GetCandy\Api\Core\Scaffold\BaseService;
 
 class ProductCustomerGroupService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Customers\Services\CustomerGroupService
+     */
     protected $groupService;
 
     public function __construct(CustomerGroupService $groups)
@@ -18,9 +21,10 @@ class ProductCustomerGroupService extends BaseService
 
     /**
      * Stores a product association.
-     * @param  string $product
-     * @param  array $data
-     * @return mixed
+     * 
+     * @param  string  $product
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function store($product, $groups)
     {
@@ -41,8 +45,9 @@ class ProductCustomerGroupService extends BaseService
 
     /**
      * Destroys product customer groups.
-     * @param  string $product
-     * @return bool
+     *
+     * @param  string  $product
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function destroy($product)
     {

--- a/src/Core/Products/Services/ProductFamilyService.php
+++ b/src/Core/Products/Services/ProductFamilyService.php
@@ -15,9 +15,8 @@ class ProductFamilyService extends BaseService
     /**
      * Creates a resource from the given data.
      *
-     * @param array $data
-     *
-     * @return GetCandy\Api\Core\Models\ProductFamily
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\ProductFamily
      */
     public function create(array $data)
     {
@@ -31,12 +30,11 @@ class ProductFamilyService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $hashedId
+     * @param  string  $hashedId
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\ProductFamily
      *
-     * @throws Symfony\Component\HttpKernel\Exception
-     *
-     * @return GetCandy\Api\Core\Models\ProductFamily
+     * @throws \Exception
      */
     public function update($hashedId, array $data)
     {
@@ -58,9 +56,12 @@ class ProductFamilyService extends BaseService
 
     /**
      * Gets paginated data for the record.
-     * @param  int $length How many results per page
-     * @param  int  $page   The page to start
-     * @return Illuminate\Pagination\LengthAwarePaginator
+     * 
+     * @param  int  $length
+     * @param  int|null  $page
+     * @param  string|array|null  $relations
+     * @param  string  $keywords
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getPaginatedData($length = 50, $page = null, $relations = null, $keywords = null)
     {
@@ -80,11 +81,11 @@ class ProductFamilyService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
+     * @param  string  $id
+     * @param  string|null  $target
      * @return bool
+     * 
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function delete($hashedId, $target = null)
     {

--- a/src/Core/Products/Services/ProductService.php
+++ b/src/Core/Products/Services/ProductService.php
@@ -16,12 +16,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class ProductService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Products\Models\Product
+     */
     protected $model;
 
     /**
      * The product factory instance.
      *
-     * @var ProductInterface
+     * @var \GetCandy\Api\Core\Products\Interfaces\ProductInterface
      */
     protected $factory;
 
@@ -33,9 +36,12 @@ class ProductService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Product
+     * 
+     * @param  string  $id
+     * @param  bool  $withDrafted
+     * @return \GetCandy\Api\Core\Products\Models\Product
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id, $withDrafted = false)
     {
@@ -79,13 +85,12 @@ class ProductService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $hashedId
+     * @param  string  $hashedId
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\Product
      *
-     * @throws \Symfony\Component\HttpKernel\Exception
+     * @throws \Exception
      * @throws \GetCandy\Exceptions\InvalidLanguageException
-     *
-     * @return Product
      */
     public function update($hashedId, array $data)
     {
@@ -121,9 +126,9 @@ class ProductService extends BaseService
     /**
      * Update a products layout.
      *
-     * @param string $productId
-     * @param string $layoutId
-     * @return Product
+     * @param  string  $productId
+     * @param  string  $layoutId
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function updateLayout($productId, $layoutId)
     {
@@ -139,9 +144,10 @@ class ProductService extends BaseService
     /**
      * Creates a resource from the given data.
      *
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\Product
+     * 
      * @throws \GetCandy\Exceptions\InvalidLanguageException
-     *
-     * @return Product
      */
     public function create(array $data)
     {
@@ -254,9 +260,10 @@ class ProductService extends BaseService
 
     /**
      * Creates a product variant.
-     * @param  Product $product
-     * @param  array   $data
-     * @return Model
+     * 
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
+     * @param  array  $data
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function createVariant(Product $product, array $data = [])
     {
@@ -266,8 +273,8 @@ class ProductService extends BaseService
     }
 
     /**
-     * @param $id
-     * @return mixed
+     * @param  string  $id
+     * @return bool
      */
     public function delete($id)
     {
@@ -282,8 +289,11 @@ class ProductService extends BaseService
 
     /**
      * Gets paginated data for the record.
-     * @param  int $length How many results per page
-     * @param  int  $page   The page to start
+     * 
+     * @param  string|null  $channel
+     * @param  int  $length
+     * @param  int|null  $page
+     * @param  array  $ids
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getPaginatedData($channel = null, $length = 50, $page = null, $ids = [])
@@ -300,7 +310,8 @@ class ProductService extends BaseService
 
     /**
      * Gets the attributes from a given products id.
-     * @param  string $id
+     * 
+     * @param  string  $id
      * @return array
      */
     public function getAttributes($id)
@@ -370,8 +381,8 @@ class ProductService extends BaseService
     /**
      * Gets recommended products based on an array of products.
      *
-     * @param array|\Illuminate\Database\Eloquent\Collection $products
-     * @param int $limit
+     * @param  array|\Illuminate\Database\Eloquent\Collection  $products
+     * @param  int  $limit
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getRecommendations($products = [], $limit = 6)
@@ -397,8 +408,9 @@ class ProductService extends BaseService
 
     /**
      * Gets the attributes from a given products id.
-     * @param  string $id
-     * @return array
+     * 
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getCategories(Product $product)
     {
@@ -411,10 +423,12 @@ class ProductService extends BaseService
 
     /**
      * Updates the collections for a product.
+     * 
      * @param  string  $id
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\Product
+     * 
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Model
      */
     public function updateCollections($id, array $data)
     {
@@ -434,9 +448,8 @@ class ProductService extends BaseService
     /**
      * Get products by a stock threshold.
      *
-     * @param int $limit
-     *
-     * @return Collection
+     * @param  int  $limit
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getByStockThreshold($limit = 15)
     {

--- a/src/Core/Products/Services/ProductVariantService.php
+++ b/src/Core/Products/Services/ProductVariantService.php
@@ -9,6 +9,9 @@ use GetCandy\Api\Core\Search\Events\IndexableSavedEvent;
 
 class ProductVariantService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Products\Factories\ProductVariantFactory
+     */
     protected $factory;
 
     public function __construct(ProductVariantFactory $factory)
@@ -19,9 +22,10 @@ class ProductVariantService extends BaseService
 
     /**
      * Creates variants for a product.
-     * @param  string $id
-     * @param  array  $variant
-     * @return bool
+     * 
+     * @param  string  $id
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\Product
      */
     public function create($id, array $data)
     {
@@ -115,9 +119,8 @@ class ProductVariantService extends BaseService
     /**
      * Checks whether a variant exists by its SKU.
      *
-     * @param string $sku
-     *
-     * @return void
+     * @param  string  $sku
+     * @return bool
      */
     public function existsBySku($sku)
     {
@@ -134,12 +137,11 @@ class ProductVariantService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $hashedId
+     * @param  string  $hashedId
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Products\Models\ProductVariant
      *
-     * @throws Symfony\Component\HttpKernel\Exception
-     *
-     * @return GetCandy\Api\Core\Models\ProductVariant
+     * @throws \Exception
      */
     public function update($hashedId, array $data)
     {
@@ -222,9 +224,8 @@ class ProductVariantService extends BaseService
     /**
      * Sets and creates the customer group pricing.
      *
-     * @param array $variant
-     * @param array $prices
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\ProductVariant  $variant
+     * @param  array  $prices
      * @return void
      */
     protected function setGroupPricing($variant, $prices = [])
@@ -266,9 +267,8 @@ class ProductVariantService extends BaseService
     /**
      * Map and merge variant options.
      *
-     * @param array $options
-     * @param array $newOptions
-     *
+     * @param  array  $options
+     * @param  array  $newOptions
      * @return array
      */
     protected function mapOptions($options, $newOptions)
@@ -290,11 +290,10 @@ class ProductVariantService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
+     * @param  string  $hashedId
      * @return bool
+     * 
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function delete($hashedId)
     {
@@ -313,13 +312,15 @@ class ProductVariantService extends BaseService
 
     /**
      * Maps and sets the measurements for a variant.
-     * @param ProductVariant $variant
      * [
      *     'weight' => [
      *         'cm' => 100
      *     ]
      * ]
-     * @param array $data
+     * 
+     * @param  \GetCandy\Api\Core\Products\Models\ProductVariant  $variant
+     * @param  array  $data
+     * @return void
      */
     protected function setMeasurements($variant, $data)
     {
@@ -337,9 +338,9 @@ class ProductVariantService extends BaseService
     /**
      * Update a variants inventory.
      *
-     * @param string $variantId
-     * @param int $inventory
-     * @return void
+     * @param  string  $variantId
+     * @param  int  $inventory
+     * @return \GetCandy\Api\Core\Products\Models\ProductVariant
      */
     public function updateInventory($variantId, $inventory)
     {

--- a/src/Core/RecycleBin/Models/RecycleBin.php
+++ b/src/Core/RecycleBin/Models/RecycleBin.php
@@ -10,10 +10,17 @@ class RecycleBin extends BaseModel
 
     protected $guarded = [];
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'recycle_bin';
 
     /**
      * Get the owning recyclable model.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function recyclable()
     {

--- a/src/Core/RecycleBin/Services/RecycleBinService.php
+++ b/src/Core/RecycleBin/Services/RecycleBinService.php
@@ -11,7 +11,11 @@ class RecycleBinService implements RecycleBinServiceInterface
     /**
      * Gets items that are currently soft deleted.
      *
-     * @return void
+     * @param  bool  $paginated
+     * @param  int  $perPage
+     * @param  mixed  $terms
+     * @param  array  $includes
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getItems($paginated = true, $perPage = 25, $terms = null, $includes = [])
     {

--- a/src/Core/Reports/Providers/AbstractProvider.php
+++ b/src/Core/Reports/Providers/AbstractProvider.php
@@ -18,23 +18,23 @@ abstract class AbstractProvider
     /**
      * The from date for the query.
      *
-     * @var DateTime
+     * @var \DateTime
      */
     protected $from;
 
     /**
      * The from date for the query.
      *
-     * @var DateTime
+     * @var \DateTime
      */
     protected $to;
 
     /**
      * Sets the date range for the provider.
      *
-     * @param DateTime $from
-     * @param DateTime $to
-     * @return self
+     * @param  \DateTime  $from
+     * @param  \DateTime  $to
+     * @return $this
      */
     public function between(DateTime $from, DateTime $to)
     {
@@ -54,8 +54,8 @@ abstract class AbstractProvider
     /**
      * Set the mode value.
      *
-     * @param string $mode
-     * @return self
+     * @param  string  $mode
+     * @return $this
      */
     public function mode($mode)
     {
@@ -85,7 +85,10 @@ abstract class AbstractProvider
 
     /**
      * Gets order within the date range.
-     * @return \Illuminate\Support\Collection
+     *
+     * @param  \DateTime  $from
+     * @param  \DateTime  $to
+     * @return \Illuminate\Database\Query\Builder
      */
     protected function getOrderQuery(DateTime $from = null, DateTime $to = null)
     {
@@ -97,8 +100,11 @@ abstract class AbstractProvider
     }
 
     /**
-     * Gets order within the date range.
-     * @return \Illuminate\Support\Collection
+     * Gets order line within the date range.
+     *
+     * @param  \DateTime  $from
+     * @param  \DateTime  $to
+     * @return \Illuminate\Database\Query\Builder
      */
     protected function getOrderLineQuery(DateTime $from = null, DateTime $to = null)
     {

--- a/src/Core/Reports/ReportManager.php
+++ b/src/Core/Reports/ReportManager.php
@@ -12,7 +12,7 @@ class ReportManager extends Manager implements ReportManagerContract
     /**
      * Get a driver instance.
      *
-     * @param  string  $driver
+     * @param  string|null  $driver
      * @return mixed
      */
     public function with($driver = null)
@@ -23,7 +23,7 @@ class ReportManager extends Manager implements ReportManagerContract
     /**
      * Create the Sales driver.
      *
-     * @return Sales
+     * @return \GetCandy\Api\Core\Reports\Providers\Sales
      */
     public function createSalesDriver()
     {
@@ -35,7 +35,7 @@ class ReportManager extends Manager implements ReportManagerContract
     /**
      * Create the Sales driver.
      *
-     * @return Orders
+     * @return \GetCandy\Api\Core\Reports\Providers\Orders
      */
     public function createOrdersDriver()
     {
@@ -48,7 +48,7 @@ class ReportManager extends Manager implements ReportManagerContract
      * Build a layout provider instance.
      *
      * @param  string  $provider
-     * @param  array  $config
+     * @return \GetCandy\Api\Core\Reports\Providers\AbstractProvider
      */
     public function buildProvider($provider)
     {
@@ -58,9 +58,9 @@ class ReportManager extends Manager implements ReportManagerContract
     /**
      * Get the default driver name.
      *
-     * @throws \InvalidArgumentException
-     *
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     public function getDefaultDriver()
     {

--- a/src/Core/Routes/Models/Route.php
+++ b/src/Core/Routes/Models/Route.php
@@ -11,7 +11,13 @@ class Route extends BaseModel
     use SoftDeletes,
         Draftable;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
+
     /**
      * The attributes that are mass assignable.
      *
@@ -23,6 +29,8 @@ class Route extends BaseModel
 
     /**
      * Get all of the owning element models.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function element()
     {

--- a/src/Core/Routes/Services/RouteService.php
+++ b/src/Core/Routes/Services/RouteService.php
@@ -15,8 +15,11 @@ class RouteService extends BaseService
 
     /**
      * Gets a route by a given slug.
-     * @param  string $slug
-     * @return Route
+     * 
+     * @param  string  $slug
+     * @return \GetCandy\Api\Core\Routes\Models\Route
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getBySlug($slug)
     {
@@ -48,8 +51,9 @@ class RouteService extends BaseService
     }
 
     /**
-     * @param $hashedId
-     * @return mixed
+     * @param  string  $hashedId
+     * @return bool
+     *
      * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      */
     public function delete($hashedId)
@@ -75,7 +79,8 @@ class RouteService extends BaseService
 
     /**
      * Gets a new suggested default model.
-     * @return mixed
+     * 
+     * @return \GetCandy\Api\Core\Routes\Models\Route
      */
     public function getNewSuggestedDefault()
     {

--- a/src/Core/Scaffold/AbstractCriteria.php
+++ b/src/Core/Scaffold/AbstractCriteria.php
@@ -34,6 +34,9 @@ abstract class AbstractCriteria
      */
     protected $offset;
 
+    /**
+     * @var bool
+     */
     protected $paginated = true;
 
     /**
@@ -82,8 +85,8 @@ abstract class AbstractCriteria
     /**
      * Set the includes to eager load.
      *
-     * @param array|string $arrayOrString
-     * @return void
+     * @param  array|string  $arrayOrString
+     * @return $this
      */
     public function include($arrayOrString = [])
     {
@@ -124,6 +127,8 @@ abstract class AbstractCriteria
      * Get the first result from the query.
      *
      * @return \Illuminate\Database\Eloquent\Model
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function firstOrFail()
     {
@@ -138,7 +143,7 @@ abstract class AbstractCriteria
     /**
      * Get the result.
      *
-     * @return LengthAwarePaginator
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function get()
     {

--- a/src/Core/Scaffold/AbstractFactory.php
+++ b/src/Core/Scaffold/AbstractFactory.php
@@ -10,14 +10,14 @@ abstract class AbstractFactory
     /**
      * The price calculator instance.
      *
-     * @var PriceCalculatorInterface
+     * @var \GetCandy\Api\Core\Pricing\PriceCalculatorInterface
      */
     protected $calculator;
 
     /**
      * The GetCandy manager.
      *
-     * @var GetCandy
+     * @var \GetCandy\Api\Core\GetCandy
      */
     protected $api;
 

--- a/src/Core/Scaffold/BaseModel.php
+++ b/src/Core/Scaffold/BaseModel.php
@@ -10,6 +10,11 @@ abstract class BaseModel extends Model
 {
     use Hashids;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     public $custom_attributes = [];
@@ -39,7 +44,7 @@ abstract class BaseModel extends Model
     /**
      * Scope a query to only include enabled.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeEnabled($query)
@@ -50,7 +55,7 @@ abstract class BaseModel extends Model
     /**
      * Scope a query to only include the default record.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeDefault($query)

--- a/src/Core/Scaffold/BaseService.php
+++ b/src/Core/Scaffold/BaseService.php
@@ -24,9 +24,11 @@ abstract class BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     * 
+     * @param  string  $id
+     * @return \Illuminate\Database\Eloquent\Model
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id)
     {
@@ -37,8 +39,9 @@ abstract class BaseService
 
     /**
      * Get a collection of models from given Hashed IDs.
+     * 
      * @param  array  $ids
-     * @return Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getByHashedIds(array $ids)
     {
@@ -52,6 +55,7 @@ abstract class BaseService
 
     /**
      * Returns the record count for the model.
+     *
      * @return int
      */
     public function count()
@@ -66,7 +70,8 @@ abstract class BaseService
 
     /**
      * Gets the decoded id for the model.
-     * @param  string $hash
+     *
+     * @param  string  $hash
      * @return int
      */
     public function getDecodedId($hash)
@@ -106,7 +111,8 @@ abstract class BaseService
 
     /**
      * Returns the record considered the default.
-     * @return mixed
+     *
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function getDefaultRecord()
     {
@@ -115,7 +121,9 @@ abstract class BaseService
 
     /**
      * Get a record by it's handle.
-     * @return mixed
+     *
+     * @param  string  $handle
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function getByHandle($handle)
     {
@@ -124,9 +132,11 @@ abstract class BaseService
 
     /**
      * Gets paginated data for the record.
-     * @param  int $length How many results per page
-     * @param  int  $page   The page to start
-     * @return Illuminate\Pagination\LengthAwarePaginator
+     * 
+     * @param  int  $length
+     * @param  int|null  $page
+     * @param  array|string|null  $relations
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getPaginatedData($length = 50, $page = null, $relations = null)
     {
@@ -141,7 +151,8 @@ abstract class BaseService
 
     /**
      * Gets a new suggested default model.
-     * @return mixed
+     * 
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function getNewSuggestedDefault()
     {
@@ -150,7 +161,9 @@ abstract class BaseService
 
     /**
      * Sets the passed model as the new default.
-     * @param Illuminate\Database\Eloquent\Model &$model
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  &$model
+     * @return void
      */
     protected function setNewDefault(&$model)
     {
@@ -163,7 +176,8 @@ abstract class BaseService
 
     /**
      * Determines whether a record exists by a given code.
-     * @param  string $code
+     *
+     * @param  string  $code
      * @return bool
      */
     public function existsByCode($code)
@@ -173,7 +187,8 @@ abstract class BaseService
 
     /**
      * Checks whether a record exists with the given hashed id.
-     * @param  string $hashedId
+     *
+     * @param  string  $hashedId
      * @return bool
      */
     public function existsByHashedId($hashedId)
@@ -195,7 +210,8 @@ abstract class BaseService
 
     /**
      * Gets the attributes related to the model.
-     * @return Collection
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getAttributes($id)
     {
@@ -204,10 +220,12 @@ abstract class BaseService
 
     /**
      * Updates the attributes for a model.
+     *
      * @param  string  $model
      * @param  array  $data
+     * @return \Illuminate\Database\Eloquent\Model
+     *
      * @throws Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Model
      */
     public function updateAttributes($id, array $data)
     {
@@ -224,6 +242,7 @@ abstract class BaseService
 
     /**
      * Validates the integrity of the attribute data.
+     *
      * @param  array  $data
      * @return bool
      */
@@ -240,8 +259,9 @@ abstract class BaseService
 
     /**
      * Checks the structure of an array against another.
-     * @param  array|null $structure
-     * @param  array|null     $data
+     *
+     * @param  array|null  $structure
+     * @param  array|null  $data
      * @return bool
      */
     protected function validateStructure(array $structure = null, $data = null)
@@ -333,9 +353,8 @@ abstract class BaseService
     /**
      * Gets the mapping for the channel data.
      *
-     * @param array $data
-     *
-     * @return void
+     * @param  array  $data
+     * @return array
      */
     protected function getChannelMapping($data)
     {
@@ -352,7 +371,8 @@ abstract class BaseService
 
     /**
      * Maps customer group data for a model.
-     * @param  array $groups
+     *
+     * @param  array  $groups
      * @return array
      */
     protected function mapCustomerGroupData($groups)
@@ -372,10 +392,9 @@ abstract class BaseService
     /**
      * Update a given resource from data.
      *
-     * @param string $hashedId
-     * @param array $data
-     *
-     * @return Model
+     * @param  string  $hashedId
+     * @param  array  $data
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function update($hashedId, array $data)
     {
@@ -402,9 +421,10 @@ abstract class BaseService
 
     /**
      * Creates a URL for a product.
-     * @param  string $hashedId
+     *
+     * @param  string  $hashedId
      * @param  array  $data
-     * @return Model
+     * @return \GetCandy\Api\Core\Routes\Models\Route
      */
     public function createUrl($hashedId, array $data)
     {
@@ -431,8 +451,7 @@ abstract class BaseService
     /**
      * Sets the channel mapping.
      *
-     * @param array $channels
-     *
+     * @param  array  $channels
      * @return array
      */
     protected function setChannelMapping($channels = [])

--- a/src/Core/Scopes/AbstractScope.php
+++ b/src/Core/Scopes/AbstractScope.php
@@ -25,7 +25,7 @@ abstract class AbstractScope implements Scope
     /**
      * The current user.
      *
-     * @var Model
+     * @var \Illuminate\Foundation\Auth\User
      */
     protected $user;
 
@@ -44,7 +44,7 @@ abstract class AbstractScope implements Scope
     /**
      * Resolves the scope if criteria is met.
      *
-     * @param \Closure $callback
+     * @param  \Closure  $callback
      * @return void
      */
     protected function resolve(\Closure $callback)
@@ -61,7 +61,7 @@ abstract class AbstractScope implements Scope
     /**
      * Gets the authenticated user.
      *
-     * @return Model
+     * @return \Illuminate\Foundation\Auth\User
      */
     protected function getUser()
     {

--- a/src/Core/Scopes/ChannelScope.php
+++ b/src/Core/Scopes/ChannelScope.php
@@ -30,7 +30,8 @@ class ChannelScope extends AbstractScope
     /**
      * Extend the query builder with the needed functions.
      *
-     * @param Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
      */
     public function extend(Builder $builder)
     {

--- a/src/Core/Scopes/CustomerGroupScope.php
+++ b/src/Core/Scopes/CustomerGroupScope.php
@@ -26,7 +26,8 @@ class CustomerGroupScope extends AbstractScope
     /**
      * Extend the query builder with the needed functions.
      *
-     * @param Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function extend(Builder $builder)
     {

--- a/src/Core/Scopes/ProductPricingScope.php
+++ b/src/Core/Scopes/ProductPricingScope.php
@@ -26,7 +26,8 @@ class ProductPricingScope extends AbstractScope
     /**
      * Extend the query builder with the needed functions.
      *
-     * @param Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function extend(Builder $builder)
     {

--- a/src/Core/Search/ClientContract.php
+++ b/src/Core/Search/ClientContract.php
@@ -6,7 +6,6 @@ interface ClientContract
 {
     /**
      * Searches using the given keywords.
-     * @param  string $keywords
      */
     public function search();
 }

--- a/src/Core/Search/Events/IndexableSavedEvent.php
+++ b/src/Core/Search/Events/IndexableSavedEvent.php
@@ -13,6 +13,9 @@ class IndexableSavedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
     protected $indexable;
 
     /**
@@ -33,7 +36,7 @@ class IndexableSavedEvent
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel|array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {

--- a/src/Core/Search/Factories/SearchResultFactory.php
+++ b/src/Core/Search/Factories/SearchResultFactory.php
@@ -19,14 +19,14 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * The result set.
      *
-     * @var ResultSet
+     * @var \Elastica\ResultSet
      */
     protected $results;
 
     /**
      * The fractal instance.
      *
-     * @var Manager
+     * @var \League\Fractal\Manager
      */
     protected $fractal;
 
@@ -47,7 +47,7 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * The result category.
      *
-     * @var Category
+     * @var null|\GetCandy\Api\Core\Categories\Models\Category
      */
     protected $category = null;
 
@@ -64,7 +64,7 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * The transformer to use.
      *
-     * @var AbstractTranformer
+     * @var mixed
      */
     protected $transformer;
 
@@ -92,7 +92,7 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * The current user.
      *
-     * @var Model
+     * @var null|\Illuminate\Foundation\Auth\User
      */
     protected $user = null;
 
@@ -106,8 +106,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Initialise the factory.
      *
-     * @param ResultSet $results
-     * @return void
+     * @param  \Elastica\ResultSet  $results
+     * @return $this
      */
     public function init(ResultSet $results)
     {
@@ -133,8 +133,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Set the model service.
      *
-     * @param mixed $service
-     * @return void
+     * @param  mixed  $service
+     * @return $this
      */
     public function service($service)
     {
@@ -146,8 +146,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Set the page.
      *
-     * @param int $page
-     * @return void
+     * @param  int  $page
+     * @return $this
      */
     public function page($page)
     {
@@ -159,8 +159,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Set the category.
      *
-     * @param Category $category
-     * @return void
+     * @param  \GetCandy\Api\Core\Categories\Models\Category  $category
+     * @return $this
      */
     public function category($category)
     {
@@ -172,8 +172,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Set the current user.
      *
-     * @param Model $user
-     * @return void
+     * @param  \Illuminate\Foundation\Auth\User  $user
+     * @return $this
      */
     public function user($user)
     {
@@ -185,8 +185,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Set the transformer to use.
      *
-     * @param mixed $transformer
-     * @return void
+     * @param  mixed  $transformer
+     * @return $this
      */
     public function setTransformer($transformer = null)
     {
@@ -203,8 +203,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Parse the fractal includes.
      *
-     * @param string $includes
-     * @return void
+     * @param  array  $includes
+     * @return $this
      */
     public function include($includes = [])
     {
@@ -216,8 +216,8 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Set the search type.
      *
-     * @param string $type
-     * @return void
+     * @param  string  $type
+     * @return $this
      */
     public function type($type)
     {
@@ -256,8 +256,6 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Maps the search sorting used to something we can use.
      *
-     * @param ResultSet $results
-     *
      * @return array
      */
     protected function getSort()
@@ -273,8 +271,6 @@ class SearchResultFactory implements SearchResultInterface
 
     /**
      * Get the pagination for the results.
-     *
-     * @param array $results
      *
      * @return array
      */
@@ -304,8 +300,6 @@ class SearchResultFactory implements SearchResultInterface
 
     /**
      * Get the search suggestions.
-     *
-     * @param ResultSet $results
      *
      * @return array
      */
@@ -344,9 +338,7 @@ class SearchResultFactory implements SearchResultInterface
     /**
      * Gets the aggregation fields for the results.
      *
-     * @param array $results
-     *
-     * @return void
+     * @return array
      */
     protected function getSearchAggregator()
     {

--- a/src/Core/Search/Indexable.php
+++ b/src/Core/Search/Indexable.php
@@ -61,8 +61,10 @@ class Indexable
 
     /**
      * Adds an items to an array.
-     * @param [type] $key   [description]
-     * @param [type] $value [description]
+     * 
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
      */
     public function add($key, $value)
     {

--- a/src/Core/Search/Jobs/ReindexSearchJob.php
+++ b/src/Core/Search/Jobs/ReindexSearchJob.php
@@ -35,6 +35,7 @@ class ReindexSearchJob implements ShouldQueue
     /**
      * Execute the job.
      *
+     * @param  \GetCandy\Api\Core\Search\SearchContract  $search
      * @return void
      */
     public function handle(SearchContract $search)

--- a/src/Core/Search/Listeners/IndexObjectListener.php
+++ b/src/Core/Search/Listeners/IndexObjectListener.php
@@ -10,7 +10,7 @@ class IndexObjectListener
     /**
      * Handle the event.
      *
-     * @param  ProductCreatedEvent  $event
+     * @param  \GetCandy\Api\Core\Search\Events\IndexableSavedEvent  $event
      * @return void
      */
     public function handle(IndexableSavedEvent $event)

--- a/src/Core/Search/Listeners/UpdateMappingsListener.php
+++ b/src/Core/Search/Listeners/UpdateMappingsListener.php
@@ -19,7 +19,7 @@ class UpdateMappingsListener implements ShouldQueue
     /**
      * Handle the event.
      *
-     * @param  ProductCreatedEvent  $event
+     * @param  \GetCandy\Api\Core\Attributes\Events\AttributeSavedEvent  $event
      * @return void
      */
     public function handle(AttributeSavedEvent $event)

--- a/src/Core/Search/Models/SavedSearch.php
+++ b/src/Core/Search/Models/SavedSearch.php
@@ -6,13 +6,17 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class SavedSearch extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'main';
 
     /**
      * Sets the payload attribute.
      *
-     * @param json $val
-     *
+     * @param  array  $val
      * @return void
      */
     public function setPayloadAttribute($val)
@@ -23,8 +27,7 @@ class SavedSearch extends BaseModel
     /**
      * Mutator for payload attribute.
      *
-     * @param string $val
-     *
+     * @param  array  $val
      * @return void
      */
     public function getPayLoadAttribute($val)

--- a/src/Core/Search/Providers/Elastic/AggregationSet.php
+++ b/src/Core/Search/Providers/Elastic/AggregationSet.php
@@ -4,6 +4,9 @@ namespace GetCandy\Api\Core\Search\Providers\Elastic;
 
 class AggregationSet
 {
+    /**
+     * @var array|\Illuminate\Support\Collection
+     */
     protected $aggregations = [];
 
     public function __construct()
@@ -14,9 +17,8 @@ class AggregationSet
     /**
      * Add a filter to the chain.
      *
-     * @param string $type
-     * @param mixed $payload
-     * @return self
+     * @param  string  $type
+     * @return $this
      */
     public function add($type)
     {
@@ -37,7 +39,7 @@ class AggregationSet
     /**
      * Find the filter class.
      *
-     * @param string $type
+     * @param  string  $type
      * @return mixed
      */
     private function findAggregation($type)

--- a/src/Core/Search/Providers/Elastic/Aggregators/AbstractAggregator.php
+++ b/src/Core/Search/Providers/Elastic/Aggregators/AbstractAggregator.php
@@ -24,8 +24,8 @@ abstract class AbstractAggregator
     /**
      * Set the filter on the aggregation.
      *
-     * @param mixed $filter
-     * @return Attribute
+     * @param  mixed  $filter
+     * @return $this
      */
     public function addFilter($filter = null)
     {

--- a/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
+++ b/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
@@ -19,7 +19,7 @@ class Attribute
     /**
      * The field to aggregate.
      *
-     * @var [type]
+     * @var mixed
      */
     protected $field;
 
@@ -31,8 +31,8 @@ class Attribute
     /**
      * Set the filter on the aggregation.
      *
-     * @param mixed $filter
-     * @return Attribute
+     * @param  mixed  $filter
+     * @return $this
      */
     public function addFilter($filter = null)
     {

--- a/src/Core/Search/Providers/Elastic/Aggregators/Category.php
+++ b/src/Core/Search/Providers/Elastic/Aggregators/Category.php
@@ -18,6 +18,9 @@ class Category extends AbstractAggregator
      */
     protected $categories = [];
 
+    /**
+     * @var string
+     */
     protected $field = 'departments';
 
     /**
@@ -30,8 +33,8 @@ class Category extends AbstractAggregator
     /**
      * Set the filter on the aggregation.
      *
-     * @param mixed $filter
-     * @return Attribute
+     * @param  mixed  $filter
+     * @return $this
      */
     public function addFilter($filter = null)
     {
@@ -104,6 +107,7 @@ class Category extends AbstractAggregator
     /**
      * Get the post filter.
      *
+     * @param  array  $value 
      * @return void
      */
     public function getPost($value)

--- a/src/Core/Search/Providers/Elastic/Aggregators/PriceRange.php
+++ b/src/Core/Search/Providers/Elastic/Aggregators/PriceRange.php
@@ -10,9 +10,10 @@ class PriceRange extends AbstractAggregator
     /**
      * Get the pre aggregation.
      *
-     * @param Search $search
-     * @param Query $query
-     * @return Query
+     * @param  null|\Elastica\Search  $search
+     * @param  null|\Elastica\Query  $query
+     * @param  mixed  $postFilter
+     * @return \Elastica\Query
      */
     public function getPre(Search $search = null, $query = null, $postFilter = null)
     {

--- a/src/Core/Search/Providers/Elastic/Elastic.php
+++ b/src/Core/Search/Providers/Elastic/Elastic.php
@@ -7,8 +7,14 @@ use GetCandy\Api\Core\Search\SearchContract;
 
 class Elastic implements SearchContract
 {
+    /**
+     * @var \GetCandy\Api\Core\Search\Providers\Elastic\Search
+     */
     protected $client;
 
+    /**
+     * @var \GetCandy\Api\Core\Search\Providers\Elastic\Indexer
+     */
     protected $indexer;
 
     public function __construct(Search $client, Indexer $indexer)

--- a/src/Core/Search/Providers/Elastic/FilterSet.php
+++ b/src/Core/Search/Providers/Elastic/FilterSet.php
@@ -18,9 +18,9 @@ class FilterSet
     /**
      * Add a filter to the chain.
      *
-     * @param mixed $type
-     * @param mixed $payload
-     * @return self
+     * @param  mixed  $type
+     * @param  mixed  $payload
+     * @return $this
      */
     public function add($type, $payload = null)
     {
@@ -36,8 +36,8 @@ class FilterSet
     /**
      * Add many filters to the search.
      *
-     * @param array $filters
-     * @return object
+     * @param  array  $filters
+     * @return $this
      */
     public function addMany(array $filters)
     {
@@ -49,9 +49,7 @@ class FilterSet
     }
 
     /**
-     * Undocumented function.
-     *
-     * @return void
+     * @return \Illuminate\Support\Collection
      */
     public function getFilters()
     {
@@ -61,7 +59,7 @@ class FilterSet
     /**
      * Get the filterable fields.
      *
-     * @return void
+     * @return mixed
      */
     public function getFilterable()
     {
@@ -71,7 +69,7 @@ class FilterSet
     /**
      * Get a filter from the chain.
      *
-     * @param string $handle
+     * @param  string  $handle
      * @return mixed
      */
     public function getFilter($handle)
@@ -82,7 +80,7 @@ class FilterSet
     /**
      * Find a matching attribute based on filter type.
      *
-     * @param string $type
+     * @param  string  $type
      * @return mixed
      */
     protected function getAttribute($type)
@@ -93,7 +91,7 @@ class FilterSet
     /**
      * Find the filter class.
      *
-     * @param string $type
+     * @param  string  $type
      * @return mixed
      */
     private function findFilter($type)

--- a/src/Core/Search/Providers/Elastic/Filters/AbstractFilter.php
+++ b/src/Core/Search/Providers/Elastic/Filters/AbstractFilter.php
@@ -26,7 +26,7 @@ abstract class AbstractFilter
     /**
      * Process the payload.
      *
-     * @param mixed $payload
+     * @param  mixed  $payload
      * @return self
      */
     abstract public function process($payload, $type = null);

--- a/src/Core/Search/Providers/Elastic/Filters/CategoryFilter.php
+++ b/src/Core/Search/Providers/Elastic/Filters/CategoryFilter.php
@@ -38,8 +38,8 @@ class CategoryFilter extends AbstractFilter
     /**
      * Add a category into the mix.
      *
-     * @param string $category
-     * @return self
+     * @param  string  $category
+     * @return $this
      */
     protected function add($category)
     {
@@ -51,7 +51,7 @@ class CategoryFilter extends AbstractFilter
     /**
      * Get the query for the filter.
      *
-     * @return mixed
+     * @return \Elastica\Query\BoolQuery
      */
     public function getQuery()
     {
@@ -84,7 +84,7 @@ class CategoryFilter extends AbstractFilter
     /**
      * Get an aggregation based on this filter.
      *
-     * @return void
+     * @return \GetCandy\Api\Core\Search\Providers\Elastic\Aggregators\Category
      */
     public function aggregate()
     {

--- a/src/Core/Search/Providers/Elastic/Filters/PriceFilter.php
+++ b/src/Core/Search/Providers/Elastic/Filters/PriceFilter.php
@@ -30,7 +30,7 @@ class PriceFilter extends AbstractFilter
     /**
      * Get the query for the filter.
      *
-     * @return mixed
+     * @return \Elastica\Query\BoolQuery
      */
     public function getQuery()
     {

--- a/src/Core/Search/Providers/Elastic/Filters/TextFilter.php
+++ b/src/Core/Search/Providers/Elastic/Filters/TextFilter.php
@@ -47,7 +47,7 @@ class TextFilter extends AbstractFilter
     /**
      * Get an aggregation based on this filter.
      *
-     * @return void
+     * @return \GetCandy\Api\Core\Search\Providers\Elastic\Aggregators\Attribute
      */
     public function aggregate()
     {

--- a/src/Core/Search/Providers/Elastic/Indexer.php
+++ b/src/Core/Search/Providers/Elastic/Indexer.php
@@ -16,19 +16,22 @@ class Indexer
 {
     // use InteractsWithIndex;
 
+    /**
+     * @var int
+     */
     protected $batch = 0;
 
     /**
      * The language service instance.
      *
-     * @var LanguageService
+     * @var \GetCandy\Api\Core\Languages\Services\LanguageService
      */
     protected $lang;
 
     /**
      * The indice resolver.
      *
-     * @var IndiceResolver
+     * @var \GetCandy\Api\Core\Search\Providers\Elastic\IndiceResolver
      */
     protected $resolver;
 
@@ -42,7 +45,7 @@ class Indexer
     /**
      * Reindex a model.
      *
-     * @param Model $model
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
     public function reindex($model)
@@ -147,7 +150,9 @@ class Indexer
 
     /**
      * Updates the mappings for the model.
-     * @param  Elastica\Index $index
+     *
+     * @param  \Elastica\Index  $index
+     * @param  mixed  $type
      * @return void
      */
     public function updateMappings($index, $type)
@@ -164,8 +169,8 @@ class Indexer
     /**
      * Gets a timestamped index.
      *
-     * @param [type] $type
-     * @return void
+     * @param  mixed  $type
+     * @return string
      */
     protected function getIndexName($type)
     {
@@ -177,8 +182,8 @@ class Indexer
     /**
      * Index a single object.
      *
-     * @param Model $model
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
      */
     public function indexObject(Model $model)
     {
@@ -321,8 +326,8 @@ class Indexer
     /**
      * Cleans up the indexes for next time.
      *
-     * @param string $suffix
-     * @param array $aliases
+     * @param  string  $suffix
+     * @param  array  $aliases
      * @return void
      */
     private function cleanup($suffix, $aliases)
@@ -342,8 +347,8 @@ class Indexer
     /**
      * Add a single model to the elastic index.
      *
-     * @param Model $model
-     * @param string $suffix
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string|null  $suffix
      * @return bool
      */
     protected function addToIndex(Model $model, $suffix = null)
@@ -379,7 +384,8 @@ class Indexer
 
     /**
      * Create an index based on the model.
-     * @return void
+     *
+     * @return mixed
      */
     public function createIndex($name, $type)
     {

--- a/src/Core/Search/Providers/Elastic/IndiceResolver.php
+++ b/src/Core/Search/Providers/Elastic/IndiceResolver.php
@@ -20,8 +20,8 @@ class IndiceResolver
     /**
      * Get the document type.
      *
-     * @param Model $model
-     * @return BaseType
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \GetCandy\Api\Core\Search\Providers\Elastic\Types
      */
     public function getType($model)
     {
@@ -37,7 +37,7 @@ class IndiceResolver
 
     /**
      * Checks whether an indexer exists.
-     * @param  mixed  $model
+     * @param  string|\Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
     public function hasType($model)

--- a/src/Core/Search/Providers/Elastic/InteractsWithIndex.php
+++ b/src/Core/Search/Providers/Elastic/InteractsWithIndex.php
@@ -60,9 +60,10 @@ trait InteractsWithIndex
     /**
      * Get the type for a model.
      *
-     * @param Model|string $model
-     * @throws Symfony\Component\HttpKernel\Exception\HttpException;
-     * @return mixed
+     * @param  string|\Illuminate\Database\Eloquent\Model  $model
+     * @return \GetCandy\Api\Core\Search\Providers\Elastic\Types
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function getType($model)
     {
@@ -78,7 +79,8 @@ trait InteractsWithIndex
 
     /**
      * Checks whether an indexer exists.
-     * @param  mixed  $model
+     *
+     * @param  string|\Illuminate\Database\Eloquent\Model  $model
      * @return bool
      */
     public function hasType($model)
@@ -93,7 +95,7 @@ trait InteractsWithIndex
     /**
      * Determines if the index exists in elastic.
      *
-     * @param string $name
+     * @param  string  $name
      * @return bool
      */
     public function hasIndex($name)
@@ -106,7 +108,7 @@ trait InteractsWithIndex
     /**
      * Get the suffix of the current index.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function getCurrentIndexSuffix($name)
@@ -116,7 +118,7 @@ trait InteractsWithIndex
 
     /**
      * Updates the mappings for the model.
-     * @param  Elastica\Index $index
+     * @param  \Elastica\Index  $index
      * @return void
      */
     public function updateMappings($index)
@@ -133,7 +135,7 @@ trait InteractsWithIndex
     /**
      * Get the next suffix.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function getNextIndexSuffix($name)

--- a/src/Core/Search/Providers/Elastic/Search.php
+++ b/src/Core/Search/Providers/Elastic/Search.php
@@ -13,27 +13,36 @@ class Search implements ClientContract
     /**
      * The Search Builder.
      *
-     * @var SearchBuilder
+     * @var \GetCandy\Api\Core\Search\Providers\Elastic\SearchBuilder
      */
     protected $builder;
 
+    /**
+     * @var array
+     */
     protected $aggregators = [
         'priceRange',
     ];
 
     /**
-     * @var FilterSet
+     * @var \GetCandy\Api\Core\Search\Providers\Elastic\FilterSet
      */
     protected $filterSet;
 
+    /**
+     * @var array
+     */
     protected $categories = [];
 
+    /**
+     * @var array
+     */
     protected $sorts = [];
 
     /**
      * The filters to apply to the search.
      *
-     * @var null|array|Collection
+     * @var null|array|\Illuminate\Support\Collection
      */
     protected $filters = null;
 
@@ -45,8 +54,8 @@ class Search implements ClientContract
     /**
      * Set the user on the search.
      *
-     * @param \Illuminate\Database\Eloquent\Model $user
-     * @return self
+     * @param  null|\Illuminate\Foundation\Auth\User  $user
+     * @return $this
      */
     public function user($user = null)
     {
@@ -58,8 +67,8 @@ class Search implements ClientContract
     /**
      * Set the keywords on the builder.
      *
-     * @param string $keywords
-     * @return Search
+     * @param  string  $keywords
+     * @return $this
      */
     public function keywords($keywords = null)
     {
@@ -73,8 +82,8 @@ class Search implements ClientContract
     /**
      * Set the sorting on the builder.
      *
-     * @param array $sorts
-     * @return Search
+     * @param  array  $sorts
+     * @return $this
      */
     public function sorting($sorts)
     {
@@ -87,8 +96,9 @@ class Search implements ClientContract
     /**
      * Set up the pagination.
      *
-     * @param int $page
-     * @return Search
+     * @param  int  $page
+     * @param  int  $perPage
+     * @return $this
      */
     public function pagination($page = 1, $perPage = 30)
     {
@@ -101,7 +111,8 @@ class Search implements ClientContract
     /**
      * Set the channel to filter on.
      *
-     * @return Search
+     * @param  string|null  $channel
+     * @return $this
      */
     public function on($channel = null)
     {
@@ -113,8 +124,8 @@ class Search implements ClientContract
     /**
      * Set the index.
      *
-     * @param string $index
-     * @return Search
+     * @param  string  $type
+     * @return $this
      */
     public function against($type)
     {
@@ -126,8 +137,8 @@ class Search implements ClientContract
     /**
      * Set the categories.
      *
-     * @param array $categories
-     * @return Search
+     * @param  array  $categories
+     * @return $this
      */
     public function categories($categories = [])
     {
@@ -144,8 +155,8 @@ class Search implements ClientContract
     /**
      * Set the filters on the search.
      *
-     * @param array $filters
-     * @return void
+     * @param  array  $filters
+     * @return $this
      */
     public function filters($filters = [])
     {
@@ -162,8 +173,8 @@ class Search implements ClientContract
     /**
      * Set the search language.
      *
-     * @param string $lang
-     * @return self
+     * @param  string  $lang
+     * @return $this
      */
     public function language($lang = 'en')
     {
@@ -175,8 +186,8 @@ class Search implements ClientContract
     /**
      * Set the suggestions.
      *
-     * @param string $keywords
-     * @return void
+     * @param  string  $keywords
+     * @return \Elastica\ResultSet
      */
     public function suggest($keywords)
     {
@@ -193,8 +204,8 @@ class Search implements ClientContract
     /**
      * Perform a wildcard search on an SKU.
      *
-     * @param string $sku
-     * @param int $limit
+     * @param  string  $sku
+     * @param  int  $limit
      * @return \Illuminate\Support\Collection
      */
     public function searchSkus($sku, $limit = 10)
@@ -237,9 +248,8 @@ class Search implements ClientContract
     /**
      * Searches the index.
      *
-     * @param  string $keywords
-     *
-     * @return array
+     * @param  bool  $rank
+     * @return \Elastica\ResultSet
      */
     public function search($rank = true)
     {
@@ -275,7 +285,7 @@ class Search implements ClientContract
     /**
      * Find the filter class.
      *
-     * @param string $type
+     * @param  string  $type
      * @return mixed
      */
     private function findFilter($type)
@@ -298,7 +308,7 @@ class Search implements ClientContract
     /**
      * Find a matching attribute based on filter type.
      *
-     * @param string $type
+     * @param  string  $type
      * @return mixed
      */
     protected function getAttribute($type)

--- a/src/Core/Search/Providers/Elastic/SearchBuilder.php
+++ b/src/Core/Search/Providers/Elastic/SearchBuilder.php
@@ -95,6 +95,7 @@ class SearchBuilder
 
     /**
      * The scoring function.
+     *
      * @var
      */
     protected $scoring = null;
@@ -106,6 +107,9 @@ class SearchBuilder
      */
     protected $user;
 
+    /**
+     * @var array
+     */
     protected $topFilters = [
         'channel-filter',
         'customer-group-filter',
@@ -124,8 +128,8 @@ class SearchBuilder
     /**
      * Sets the search index.
      *
-     * @param string $index
-     * @return SearchBuilder
+     * @param  string  $index
+     * @return $this
      */
     public function setIndex($index)
     {
@@ -137,8 +141,8 @@ class SearchBuilder
     /**
      * Set the search term.
      *
-     * @param string $term
-     * @return SearchBuilder
+     * @param  string  $term
+     * @return $this
      */
     public function setTerm($term)
     {
@@ -150,9 +154,9 @@ class SearchBuilder
     /**
      * Add a filter to the search.
      *
-     * @param mixed $filter
-     * @param bool $post Whether this is a post filter
-     * @return SearchBuilder
+     * @param  mixed  $filter
+     * @param  bool  $post - Whether this is a post filter
+     * @return $this
      */
     public function addFilter($filter, $post = true)
     {
@@ -168,8 +172,8 @@ class SearchBuilder
     /**
      * Set the channel to search on.
      *
-     * @param string $channel
-     * @return SearchBuilder
+     * @param  string  $channel
+     * @return $this
      */
     public function setChannel($channel)
     {
@@ -181,8 +185,8 @@ class SearchBuilder
     /**
      * Set the function score.
      *
-     * @param mixed $score
-     * @return void
+     * @param  mixed  $score
+     * @return $this
      */
     public function scoring($score)
     {
@@ -194,8 +198,8 @@ class SearchBuilder
     /**
      * Set the search limit.
      *
-     * @param int $limit
-     * @return SeachBuilder
+     * @param  int  $limit
+     * @return $this
      */
     public function setLimit($limit)
     {
@@ -207,8 +211,8 @@ class SearchBuilder
     /**
      * Set the search offset.
      *
-     * @param integar $offset
-     * @return SearchBuilder
+     * @param  int  $offset
+     * @return $this
      */
     public function setOffset($offset)
     {
@@ -230,8 +234,8 @@ class SearchBuilder
     /**
      * Set the user.
      *
-     * @param mixed $user
-     * @return SearchBuilder
+     * @param  mixed  $user
+     * @return $this
      */
     public function setUser($user)
     {
@@ -243,7 +247,7 @@ class SearchBuilder
     /**
      * Init customer group filters.
      *
-     * @return SearchBuilder
+     * @return $this
      */
     public function useCustomerFilters()
     {
@@ -257,8 +261,8 @@ class SearchBuilder
     /**
      * Set the type.
      *
-     * @param string $type
-     * @return SearchBuilder
+     * @param  string  $type
+     * @return $this
      */
     public function setType($type)
     {
@@ -282,9 +286,9 @@ class SearchBuilder
     /**
      * Add a sort to the builder.
      *
-     * @param mixed $type
-     * @param mixed $payload
-     * @return SearchBuilder
+     * @param  mixed  $type
+     * @param  mixed  $payload
+     * @return $this
      */
     public function addSort($type, $payload)
     {
@@ -298,7 +302,7 @@ class SearchBuilder
     /**
      * Get the user.
      *
-     * @return User
+     * @return mixed
      */
     public function getUser()
     {
@@ -323,7 +327,7 @@ class SearchBuilder
     /**
      * Set up aggregations based on our attributes.
      *
-     * @return SearchBuilder
+     * @return $this
      */
     public function withAggregations()
     {
@@ -349,7 +353,7 @@ class SearchBuilder
     /**
      * Get the attributes.
      *
-     * @return Collection
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getAttributes()
     {
@@ -359,8 +363,8 @@ class SearchBuilder
     /**
      * Set the sorting on the search.
      *
-     * @param array $sorts
-     * @return SearchBuilder
+     * @param  array|null  $sortables
+     * @return $this
      */
     public function setSorting($sortables = null)
     {
@@ -418,8 +422,8 @@ class SearchBuilder
     /**
      * Add an aggregation to the builder.
      *
-     * @param GetCandy\Api\Core\Search\Providers\Elastic\Aggregators\AbstractAggregator $aggregation
-     * @return SearchBuilder
+     * @param  \GetCandy\Api\Core\Search\Providers\Elastic\Aggregators\AbstractAggregator  $aggregation
+     * @return $this
      */
     public function addAggregation($aggregation)
     {
@@ -450,7 +454,7 @@ class SearchBuilder
     /**
      * Get the search object.
      *
-     * @return Search
+     * @return \Elastica\Search
      */
     public function getSearch()
     {
@@ -470,7 +474,8 @@ class SearchBuilder
     /**
      * Get the search query.
      *
-     * @return void
+     * @param  mixed  $rank
+     * @return \Elastica\Query
      */
     public function getQuery($rank)
     {
@@ -569,7 +574,7 @@ class SearchBuilder
     /**
      * Get the suggester.
      *
-     * @return Suggest
+     * @return \Elastica\Suggest
      */
     protected function getSuggest()
     {

--- a/src/Core/Search/Providers/Elastic/Sorts/AbstractSort.php
+++ b/src/Core/Search/Providers/Elastic/Sorts/AbstractSort.php
@@ -37,7 +37,7 @@ abstract class AbstractSort
     /**
      * The authenticated user.
      *
-     * @var Model
+     * @var \Illuminate\Foundation\Auth\User
      */
     protected $user = null;
 
@@ -52,8 +52,8 @@ abstract class AbstractSort
     /**
      * Set the user on the sort.
      *
-     * @param Model $user
-     * @return void
+     * @param  \Illuminate\Foundation\Auth\User  $user
+     * @return $this
      */
     public function user(Model $user)
     {
@@ -65,8 +65,8 @@ abstract class AbstractSort
     /**
      * Set the field value.
      *
-     * @param string $field
-     * @return AbstractSort
+     * @param  string  $field
+     * @return $this
      */
     public function setField($field)
     {
@@ -78,8 +78,8 @@ abstract class AbstractSort
     /**
      * Set the sort direction.
      *
-     * @param string $dir
-     * @return AbstractSort
+     * @param  string  $dir
+     * @return $this
      */
     public function setDir($dir)
     {
@@ -91,8 +91,8 @@ abstract class AbstractSort
     /**
      * Set the mode.
      *
-     * @param string $mode
-     * @return AbstractSort
+     * @param  string  $mode
+     * @return $this
      */
     public function setMode($mode)
     {

--- a/src/Core/Search/Providers/Elastic/Sorts/CategorySort.php
+++ b/src/Core/Search/Providers/Elastic/Sorts/CategorySort.php
@@ -9,7 +9,7 @@ class CategorySort extends AbstractSort
     /**
      * The category model.
      *
-     * @var Category
+     * @var \GetCandy\Api\Core\Categories\Models\Category
      */
     protected $category;
 

--- a/src/Core/Search/Providers/Elastic/Types/BaseType.php
+++ b/src/Core/Search/Providers/Elastic/Types/BaseType.php
@@ -37,8 +37,8 @@ abstract class BaseType
     /**
      * Gets a collection of indexables, based on a model.
      *
-     * @param [type] $product
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return mixed
      */
     protected function getIndexables(Model $model)
     {
@@ -124,7 +124,7 @@ abstract class BaseType
     /**
      * Gets the attribute mapping for a model to be indexed.
      *
-     * @param Model $model
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return array
      */
     public function attributeMapping(Model $model)
@@ -163,8 +163,8 @@ abstract class BaseType
     /**
      * Gets any attributes which are marked as searchable.
      *
-     * @param Model $model
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     protected function getIndexableAttributes(Model $model)
     {
@@ -176,8 +176,8 @@ abstract class BaseType
     /**
      * Gets an indexable object.
      *
-     * @param array $attributes
-     * @return Indexable
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \GetCandy\Api\Core\Search\Indexable
      */
     protected function getIndexable(Model $model)
     {
@@ -191,8 +191,9 @@ abstract class BaseType
     /**
      * Gets the category mapping for an indexable.
      *
-     * @param Model $model
-     * @return array
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $lang
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     protected function getCategories(Model $model, $lang = 'en')
     {

--- a/src/Core/Search/Providers/Elastic/Types/CategoryType.php
+++ b/src/Core/Search/Providers/Elastic/Types/CategoryType.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 class CategoryType extends BaseType
 {
     /**
-     * @var Product
+     * @var string
      */
     protected $model = Category::class;
 
@@ -95,8 +95,9 @@ class CategoryType extends BaseType
 
     /**
      * Returns the Index document ready to be added.
-     * @param  Product $product
-     * @return Document
+     *
+     * @param  \GetCandy\Api\Core\Categories\Models\Category  $category
+     * @return mixed
      */
     public function getIndexDocument(Category $category)
     {

--- a/src/Core/Search/Providers/Elastic/Types/ProductType.php
+++ b/src/Core/Search/Providers/Elastic/Types/ProductType.php
@@ -8,7 +8,7 @@ use GetCandy\Api\Core\Products\Models\Product;
 class ProductType extends BaseType
 {
     /**
-     * @var Product
+     * @var string
      */
     protected $model = Product::class;
 
@@ -166,8 +166,9 @@ class ProductType extends BaseType
 
     /**
      * Returns the Index document ready to be added.
-     * @param  Product $product
-     * @return Document
+     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
+     * @return mixed
      */
     public function getIndexDocument(Product $product)
     {

--- a/src/Core/Search/Services/SavedSearchService.php
+++ b/src/Core/Search/Services/SavedSearchService.php
@@ -16,9 +16,8 @@ class SavedSearchService extends BaseService
     /**
      * Gets the saved searches for a model.
      *
-     * @param mixed $model
-     *
-     * @return Collection
+     * @param  string  $type
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getByType($type)
     {
@@ -28,9 +27,8 @@ class SavedSearchService extends BaseService
     /**
      * Stores a saved search.
      *
-     * @param array $data
-     *
-     * @return void
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Search\Models\SavedSearch
      */
     public function store($data)
     {

--- a/src/Core/Search/Services/SearchService.php
+++ b/src/Core/Search/Services/SearchService.php
@@ -12,21 +12,21 @@ class SearchService
     /**
      * The products service.
      *
-     * @var ProductService
+     * @var \GetCandy\Api\Core\Products\Services\ProductService
      */
     protected $products;
 
     /**
      * The category service.
      *
-     * @var CategoryService
+     * @var \GetCandy\Api\Core\Categories\Services\CategoryService
      */
     protected $categories;
 
     /**
      * The search result factory.
      *
-     * @var SearchResultInterface
+     * @var \GetCandy\Api\Core\Search\Interfaces\SearchResultInterface
      */
     protected $factory;
 
@@ -43,12 +43,11 @@ class SearchService
     /**
      * Gets the search results from the result set.
      *
-     * @param ResultSet $results
-     * @param string $type
-     * @param int $page
-     * @param int $perpage
-     * @param mixed $includes
-     *
+     * @param  \Elastica\ResultSet  $results
+     * @param  string  $type
+     * @param  int|null  $includes
+     * @param  int  $page
+     * @param  bool  $category
      * @return array
      */
     public function getResults(ResultSet $results, $type, $includes = null, $page = 1, $category = false)

--- a/src/Core/Settings/Models/Setting.php
+++ b/src/Core/Settings/Models/Setting.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Setting extends BaseModel
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'name',
     ];

--- a/src/Core/Shipping/Models/ShippingMethod.php
+++ b/src/Core/Shipping/Models/ShippingMethod.php
@@ -15,6 +15,8 @@ class ShippingMethod extends BaseModel
         HasChannels;
 
     /**
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'main';
@@ -30,6 +32,11 @@ class ShippingMethod extends BaseModel
         static::addGlobalScope(new ChannelScope);
     }
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'attribute_data',
         'type',
@@ -52,7 +59,8 @@ class ShippingMethod extends BaseModel
 
     /**
      * Get the attributes associated to the product.
-     * @return Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function channels()
     {

--- a/src/Core/Shipping/Models/ShippingPrice.php
+++ b/src/Core/Shipping/Models/ShippingPrice.php
@@ -12,10 +12,17 @@ class ShippingPrice extends BaseModel
     use HasCustomerGroups;
 
     /**
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'main';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'rate',
         'fixed',

--- a/src/Core/Shipping/Models/ShippingZone.php
+++ b/src/Core/Shipping/Models/ShippingZone.php
@@ -8,10 +8,17 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 class ShippingZone extends BaseModel
 {
     /**
+     * The Hashid connection name for enconding the id.
+     * 
      * @var string
      */
     protected $hashids = 'main';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'name',
     ];

--- a/src/Core/Shipping/Providers/AbstractProvider.php
+++ b/src/Core/Shipping/Providers/AbstractProvider.php
@@ -5,9 +5,7 @@ namespace GetCandy\Api\Core\Shipping\Providers;
 abstract class AbstractProvider
 {
     /**
-     * Order.
-     *
-     * @var Order
+     * @var \GetCandy\Api\Core\Orders\Models\Order
      */
     protected $order;
 

--- a/src/Core/Shipping/Providers/RegionalProvider.php
+++ b/src/Core/Shipping/Providers/RegionalProvider.php
@@ -9,8 +9,8 @@ class RegionalProvider extends AbstractProvider
     /**
      * Calculates the shipping prices available.
      *
-     * @param \GetCandy\Api\Core\Orders\Models\Order $order
-     * @return ShippingPrice|null
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingPrice|null
      */
     public function calculate($order)
     {
@@ -61,7 +61,7 @@ class RegionalProvider extends AbstractProvider
     /**
      * Gets the postcode which should be used to check prices.
      *
-     * @param \GetCandy\Api\Core\Orders\Models\Order $order
+     * @param  \GetCandy\Api\Core\Orders\Models\Order  $order
      * @return string
      */
     protected function getPostcodeToCheck($order)

--- a/src/Core/Shipping/Services/ShippingMethodService.php
+++ b/src/Core/Shipping/Services/ShippingMethodService.php
@@ -11,12 +11,15 @@ use Illuminate\Pipeline\Pipeline;
 
 class ShippingMethodService extends BaseService
 {
+    /**
+     * @var array
+     */
     protected $pipes = [];
 
     /**
      * The basket service.
      *
-     * @var BasketService
+     * @var \GetCandy\Api\Core\Baskets\Services\BasketService
      */
     protected $baskets;
 
@@ -30,9 +33,8 @@ class ShippingMethodService extends BaseService
     /**
      * Create a shipping method.
      *
-     * @param array $data
-     *
-     * @return ShippingMethod
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingMethod
      */
     public function create(array $data)
     {
@@ -56,10 +58,9 @@ class ShippingMethodService extends BaseService
     /**
      * Update a shipping method.
      *
-     * @param string $id
-     * @param array $data
-     *
-     * @return ShippingMethod
+     * @param  string  $id
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingMethod
      */
     public function update($id, array $data)
     {
@@ -90,9 +91,11 @@ class ShippingMethodService extends BaseService
 
     /**
      * Gets paginated data for the record.
-     * @param  int $length How many results per page
-     * @param  int  $page   The page to start
-     * @return Illuminate\Pagination\LengthAwarePaginator
+     *
+     * @param  int  $length
+     * @param  int|null  $page
+     * @param  array|string|null  $relations
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getPaginatedData($length = 50, $page = null, $relations = null)
     {
@@ -107,9 +110,12 @@ class ShippingMethodService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     *
+     * @param  string  $id
+     * @param  array  $includes
+     * @return \Illuminate\Database\Eloquent\Model
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id, $includes = [])
     {
@@ -121,9 +127,8 @@ class ShippingMethodService extends BaseService
     /**
      * Gets shipping methods for an order.
      *
-     * @param string $orderId
-     *
-     * @return ArrayCollection
+     * @param  string  $orderId
+     * @return mixed
      */
     public function getForOrder($orderId)
     {
@@ -179,10 +184,9 @@ class ShippingMethodService extends BaseService
     /**
      * Updates zones for a shipping method.
      *
-     * @param string $methodId
-     * @param array $data
-     *
-     * @return ShippingMethod
+     * @param  string  $methodId
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingMethod
      */
     public function updateZones($methodId, $data = [])
     {
@@ -202,10 +206,9 @@ class ShippingMethodService extends BaseService
     /**
      * Update users for a shipping method.
      *
-     * @param string $methodId
-     * @param array $users
-     *
-     * @return ShippingMethod
+     * @param  string  $methodId
+     * @param  array  $users
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingMethod
      */
     public function updateUsers($methodId, $users = [])
     {
@@ -223,10 +226,9 @@ class ShippingMethodService extends BaseService
     /**
      * Remove a user from a shipping method.
      *
-     * @param string $methodId
-     * @param string $userId
-     *
-     * @return ShippingMethod
+     * @param  string  $methodId
+     * @param  string  $userId
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingMethod
      */
     public function deleteUser($methodId, $userId)
     {

--- a/src/Core/Shipping/Services/ShippingPriceService.php
+++ b/src/Core/Shipping/Services/ShippingPriceService.php
@@ -16,9 +16,9 @@ class ShippingPriceService extends BaseService
     /**
      * Create a shipping price.
      *
-     * @param array $data
-     *
-     * @return ShippingPrice
+     * @param  string  $shippingMethodId
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingPrice
      */
     public function create($shippingMethodId, array $data)
     {
@@ -43,10 +43,9 @@ class ShippingPriceService extends BaseService
     /**
      * Updates a shipping price.
      *
-     * @param string $id
-     * @param array $data
-     *
-     * @return ShippingPrice
+     * @param  string  $id
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingPrice
      */
     public function update($id, array $data)
     {
@@ -69,7 +68,8 @@ class ShippingPriceService extends BaseService
 
     /**
      * Maps customer group data for a model.
-     * @param  array $groups
+     *
+     * @param  array  $groups
      * @return array
      */
     protected function mapCustomerGroupData($groups)
@@ -88,8 +88,7 @@ class ShippingPriceService extends BaseService
     /**
      * Delete a price.
      *
-     * @param string $id
-     *
+     * @param  string  $id
      * @return bool
      */
     public function delete($id)
@@ -104,9 +103,10 @@ class ShippingPriceService extends BaseService
     /**
      * Estimates shipping prices for a zip and amount.
      *
-     * @param int $amount
-     * @param string $zip
-     * @return void
+     * @param  int  $amount
+     * @param  string  $zip
+     * @param  int  $limit
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function estimate($amount, $zip, $limit = 1)
     {
@@ -128,8 +128,8 @@ class ShippingPriceService extends BaseService
     /**
      * Get a region from a zip code.
      *
-     * @param string $zip
-     * @return ShippingRegion|null
+     * @param  string  $zip
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingRegion
      */
     public function getRegionFromZip($zip)
     {

--- a/src/Core/Shipping/Services/ShippingZoneService.php
+++ b/src/Core/Shipping/Services/ShippingZoneService.php
@@ -15,9 +15,8 @@ class ShippingZoneService extends BaseService
     /**
      * Create a shipping method.
      *
-     * @param array $data
-     *
-     * @return ShippingZone
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingZone
      */
     public function create(array $data)
     {
@@ -36,9 +35,12 @@ class ShippingZoneService extends BaseService
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     *
+     * @param  string  $id
+     * @param  array|null  $includes
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingZone
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id, $includes = null)
     {
@@ -56,10 +58,9 @@ class ShippingZoneService extends BaseService
     /**
      * Updates a shipping zone.
      *
-     * @param string $id
-     * @param array $data
-     *
-     * @return ShippingZone
+     * @param  string  $id
+     * @param  array  $data
+     * @return \GetCandy\Api\Core\Shipping\Models\ShippingZone
      */
     public function update($id, array $data)
     {

--- a/src/Core/Tags/Models/Tag.php
+++ b/src/Core/Tags/Models/Tag.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Tag extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'tag';
 
     /**
@@ -24,6 +29,8 @@ class Tag extends BaseModel
 
     /**
      * Get all of the tags for the post.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function taggables()
     {

--- a/src/Core/Tags/Services/TagService.php
+++ b/src/Core/Tags/Services/TagService.php
@@ -7,6 +7,9 @@ use GetCandy\Api\Core\Tags\Models\Tag;
 
 class TagService extends BaseService
 {
+    /**
+     * @var \GetCandy\Api\Core\Tags\Models\Tag
+     */
     protected $model;
 
     public function __construct()
@@ -18,8 +21,7 @@ class TagService extends BaseService
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return GetCandy\Api\Core\Models\Tag
+     * @return \GetCandy\Api\Core\Tags\Models\Tag
      */
     public function create(array $data)
     {
@@ -33,12 +35,11 @@ class TagService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $id
+     * @param  string  $hashedId
      * @param  array  $data
+     * @return \GetCandy\Api\Core\Tags\Models\Tag
      *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
-     * @return GetCandy\Api\Core\Models\Tag
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function update($hashedId, array $data)
     {
@@ -57,11 +58,10 @@ class TagService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
+     * @param  string  $id
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function delete($id)
     {
@@ -92,8 +92,9 @@ class TagService extends BaseService
 
     /**
      * Either returns an existing tag or makes a new one.
-     * @param  string $value
-     * @return Tag
+     *
+     * @param  string  $value
+     * @return array
      */
     public function getOrCreateTag($value)
     {
@@ -111,6 +112,7 @@ class TagService extends BaseService
 
     /**
      * Returns an array of tag ids, ready for syncing.
+     *
      * @param  array  $tags
      * @return array
      */
@@ -127,7 +129,8 @@ class TagService extends BaseService
 
     /**
      * Gets the tag name, formatted, ready to go.
-     * @param  string $value
+     *
+     * @param  string  $value
      * @return string
      */
     public function getFormattedTagName($value)

--- a/src/Core/Taxes/Models/Tax.php
+++ b/src/Core/Taxes/Models/Tax.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class Tax extends BaseModel
 {
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'tax';
 
     /**

--- a/src/Core/Taxes/Services/TaxService.php
+++ b/src/Core/Taxes/Services/TaxService.php
@@ -16,8 +16,7 @@ class TaxService extends BaseService
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return GetCandy\Api\Core\Models\Tax
+     * @return \GetCandy\Api\Core\Taxes\Models\Tax
      */
     public function create($data)
     {
@@ -48,12 +47,11 @@ class TaxService extends BaseService
     /**
      * Updates a resource from the given data.
      *
-     * @param  string $id
+     * @param  string  $id
      * @param  array  $data
-     *
-     * @throws Symfony\Component\HttpKernel\Exception
-     *
-     * @return GetCandy\Api\Core\Models\Tax
+     * @return \GetCandy\Api\Core\Taxes\Models\Tax
+     * 
+     * @throws \Exception
      */
     public function update($id, array $data)
     {
@@ -76,12 +74,11 @@ class TaxService extends BaseService
     /**
      * Deletes a resource by its given hashed ID.
      *
-     * @param  string $id
-     *
-     * @throws Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
-     *
+     * @param  string  $id
      * @return bool
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \GetCandy\Api\Exceptions\MinimumRecordRequiredException
      */
     public function delete($id)
     {

--- a/src/Core/Traits/Fractal.php
+++ b/src/Core/Traits/Fractal.php
@@ -23,6 +23,7 @@ trait Fractal
 
     /**
      * Gets the current status code.
+     *
      * @return int
      */
     public function getStatusCode()
@@ -32,7 +33,9 @@ trait Fractal
 
     /**
      * Sets the status code for the getcandy::response.
-     * @param int $statusCode
+     *
+     * @param  int  $statusCode
+     * @return $this
      */
     public function setStatusCode($statusCode)
     {
@@ -43,7 +46,9 @@ trait Fractal
 
     /**
      * Generates a Response with a 403 HTTP header and a given message.
-     * @return  Response
+     *
+     * @param  string|null  $message
+     * @return array
      */
     public function errorForbidden($message = null)
     {
@@ -53,8 +58,8 @@ trait Fractal
     /**
      * Generates a response with a 410 HTTP header and a given message.
      *
-     * @param mixed $message
-     * @return void
+     * @param  string|null  $message
+     * @return array
      */
     public function errorExpired($message = null)
     {
@@ -63,7 +68,9 @@ trait Fractal
 
     /**
      * Generates a Response with a 500 HTTP header and a given message.
-     * @return  Response
+     *
+     * @param  string|null  $message
+     * @return array
      */
     public function errorInternalError($message = null)
     {
@@ -73,7 +80,8 @@ trait Fractal
     /**
      * Generates a Response with a 401 HTTP header and a given message.
      *
-     * @return  Response
+     * @param  string|null  $message
+     * @return array
      */
     public function errorUnauthorized($message = null)
     {
@@ -85,7 +93,8 @@ trait Fractal
     /**
      * Generates a Response with a 400 HTTP header and a given message.
      *
-     * @return  Response
+     * @param  string|null  $message
+     * @return array
      */
     public function errorWrongArgs($message = null)
     {
@@ -97,7 +106,8 @@ trait Fractal
     /**
      * Generates a Response with a 404 HTTP header and a given message.
      *
-     * @return  Response
+     * @param  string|null  $message
+     * @return array
      */
     public function errorNotFound($message = null)
     {
@@ -133,8 +143,8 @@ trait Fractal
 
     /**
      * Returns an error getcandy::response.
-     * @param  string $message
-     * @param  string $errorCode
+     *
+     * @param  string|null  $message
      * @return array
      */
     protected function respondWithError($message = null)
@@ -153,8 +163,10 @@ trait Fractal
 
     /**
      * Respond with an item.
-     * @param  array $item
-     * @param  object $callback The transformer to use
+     *
+     * @param  array  $item
+     * @param  object  $callback - The transformer to use
+     * @param  array  $meta
      * @return array
      */
     protected function respondWithItem($item, $callback, $meta = [])
@@ -178,8 +190,10 @@ trait Fractal
 
     /**
      * Respond with a collection.
-     * @param  array $paginator
-     * @param  object $callback The transformer to use
+     *
+     * @param  array  $paginator
+     * @param  object  $callback - The transformer to use
+     * @param  array  $meta
      * @return array
      */
     protected function respondWithCollection($paginator, $callback, $meta = [])
@@ -213,8 +227,9 @@ trait Fractal
 
     /**
      * Builds a response array.
-     * @param  array  $array   The array of data
-     * @param  array  $headers Any headers to attach to the response
+     *
+     * @param  array  $array - The array of data
+     * @param  array  $headers - Any headers to attach to the response
      * @return array
      */
     protected function respondWithArray(array $array, array $headers = [])

--- a/src/Core/Traits/HasAttributes.php
+++ b/src/Core/Traits/HasAttributes.php
@@ -81,6 +81,7 @@ trait HasAttributes
 
     /**
      * Prepares the attribute data for saving to the database.
+     *
      * @param  array  $data
      * @return array
      */
@@ -109,6 +110,7 @@ trait HasAttributes
 
     /**
      * Gets the current attribute data mapping.
+     *
      * @return array
      */
     public function getDataMapping()

--- a/src/Core/Traits/HasCandy.php
+++ b/src/Core/Traits/HasCandy.php
@@ -17,6 +17,11 @@ trait HasCandy
     use Hashids,
         HasRoles;
 
+    /**
+     * The Hashid connection name for enconding the id.
+     * 
+     * @var string
+     */
     protected $hashids = 'user';
 
     public function groups()

--- a/src/Core/Traits/HasChannels.php
+++ b/src/Core/Traits/HasChannels.php
@@ -54,7 +54,8 @@ trait HasChannels
 
     /**
      * Get the attributes associated to the product.
-     * @return Illuminate\Database\Eloquent\Relations\BelongsToMany
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function channels()
     {

--- a/src/Core/Traits/HasMeta.php
+++ b/src/Core/Traits/HasMeta.php
@@ -7,8 +7,8 @@ trait HasMeta
     /**
      * Mutator for setting meta column.
      *
-     * @param array $val
-     * @return void
+     * @param  array|null  $val
+     * @return string|null
      */
     public function setMetaAttribute(array $val = null)
     {
@@ -18,7 +18,7 @@ trait HasMeta
     /**
      * Mutator for setting meta attribute.
      *
-     * @param string $val
+     * @param  string  $val
      * @return array
      */
     public function getMetaAttribute($val)

--- a/src/Core/Traits/HasTranslations.php
+++ b/src/Core/Traits/HasTranslations.php
@@ -6,7 +6,9 @@ trait HasTranslations
 {
     /**
      * Sets the name attribute to a json string.
-     * @param array $value
+     *
+     * @param  array  $value
+     * @return void
      */
     public function setNameAttribute($value)
     {

--- a/src/Core/Traits/IncludesAttributes.php
+++ b/src/Core/Traits/IncludesAttributes.php
@@ -10,12 +10,12 @@ use Illuminate\Database\Eloquent\Model;
 trait IncludesAttributes
 {
     /**
-     * @var
+     * @var \Illuminate\Database\Eloquent\Collection
      */
     protected $attributeGroups;
 
     /**
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getAttributeGroups()
     {
@@ -33,8 +33,7 @@ trait IncludesAttributes
     }
 
     /**
-     * @param \GetCandy\Api\Core\Products\Models\Product $product
-     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \League\Fractal\Resource\Collection
      */
     public function includeAttributeGroups(Model $model)

--- a/src/Core/Users/Models/UserDetail.php
+++ b/src/Core/Users/Models/UserDetail.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Core\Scaffold\BaseModel;
 
 class UserDetail extends BaseModel
 {
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
     protected $guarded = ['id'];
 
     public function getFieldsAttribute($val)

--- a/src/Core/Users/Services/UserService.php
+++ b/src/Core/Users/Services/UserService.php
@@ -23,7 +23,7 @@ class UserService extends BaseService implements UserContract
      * Returns model by a given hashed id.
      * 
      * @param  string  $id
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Foundation\Auth\User
      * 
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
@@ -38,7 +38,7 @@ class UserService extends BaseService implements UserContract
      * Returns model by a given email.
      *
      * @param  string  $email
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @return \Illuminate\Foundation\Auth\User|null
      */
     public function getByEmail($email)
     {
@@ -81,7 +81,7 @@ class UserService extends BaseService implements UserContract
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Foundation\Auth\User
      */
     public function create($data)
     {
@@ -141,7 +141,7 @@ class UserService extends BaseService implements UserContract
     /**
      * Delete a reusable payment.
      *
-     * @param  ReusablePayment  $payment
+     * @param  \GetCandy\Api\Core\Payments\Models\ReusablePayment  $payment
      * @return bool
      */
     public function deleteReusablePayment($payment)

--- a/src/Core/Users/Services/UserService.php
+++ b/src/Core/Users/Services/UserService.php
@@ -128,8 +128,8 @@ class UserService extends BaseService implements UserContract
     /**
      * Get a reusable payment by it's id.
      *
-     * @param string $id
-     * @return ReusablePayment
+     * @param  string  $id
+     * @return \GetCandy\Api\Core\Payments\Models\ReusablePayment
      */
     public function getReusablePayment($id)
     {
@@ -141,7 +141,7 @@ class UserService extends BaseService implements UserContract
     /**
      * Delete a reusable payment.
      *
-     * @param ReusablePayment $payment
+     * @param  ReusablePayment  $payment
      * @return bool
      */
     public function deleteReusablePayment($payment)
@@ -197,8 +197,7 @@ class UserService extends BaseService implements UserContract
     /**
      * Creates a user token.
      *
-     * @param string $userId
-     *
+     * @param  string  $userId
      * @return PersonalAccessTokenResult
      */
     public function getImpersonationToken($userId)

--- a/src/Core/Users/Services/UserService.php
+++ b/src/Core/Users/Services/UserService.php
@@ -21,9 +21,11 @@ class UserService extends BaseService implements UserContract
 
     /**
      * Returns model by a given hashed id.
-     * @param  string $id
-     * @throws  Illuminate\Database\Eloquent\ModelNotFoundException
-     * @return Illuminate\Database\Eloquent\Model
+     * 
+     * @param  string  $id
+     * @return \Illuminate\Database\Eloquent\Model
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function getByHashedId($id)
     {
@@ -32,6 +34,12 @@ class UserService extends BaseService implements UserContract
         return $this->model->with('details')->findOrFail($id);
     }
 
+    /**
+     * Returns model by a given email.
+     *
+     * @param  string  $email
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
     public function getByEmail($email)
     {
         return $this->model->where('email', '=', $email)->first();
@@ -39,9 +47,12 @@ class UserService extends BaseService implements UserContract
 
     /**
      * Gets paginated data for the record.
-     * @param  int $length How many results per page
-     * @param  int  $page   The page to start
-     * @return Illuminate\Pagination\LengthAwarePaginator
+     *
+     * @param  int  $length
+     * @param  int|null  $page
+     * @param  string|null  $keywords
+     * @param  array  $ids
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function getPaginatedData($length = 50, $page = null, $keywords = null, $ids = [])
     {
@@ -70,8 +81,7 @@ class UserService extends BaseService implements UserContract
      * Creates a resource from the given data.
      *
      * @param  array  $data
-     *
-     * @return GetCandy\Api\Core\Auth\Models\User
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function create($data)
     {

--- a/src/Core/Utils/Import/AbstractImporter.php
+++ b/src/Core/Utils/Import/AbstractImporter.php
@@ -10,7 +10,7 @@ abstract class AbstractImporter
     /**
      * The import to process.
      *
-     * @var Import
+     * @var \GetCandy\Api\Core\Utils\Import\Models\Import
      */
     protected $import;
 

--- a/src/Core/Utils/Import/ImportManager.php
+++ b/src/Core/Utils/Import/ImportManager.php
@@ -21,7 +21,7 @@ class ImportManager extends Manager implements ImportManagerContract
     /**
      * Create the PayPal driver.
      *
-     * @return Product
+     * @return \GetCandy\Api\Core\Utils\Import\Providers\Product
      */
     public function createProductDriver()
     {
@@ -34,8 +34,7 @@ class ImportManager extends Manager implements ImportManagerContract
      * Build a layout provider instance.
      *
      * @param  string  $provider
-     * @param  array  $config
-     * @return \Laravel\Socialite\Two\AbstractProvider
+     * @return mixed
      */
     public function buildProvider($provider)
     {
@@ -44,8 +43,6 @@ class ImportManager extends Manager implements ImportManagerContract
 
     /**
      * Get the default driver name.
-     *
-     * @throws \InvalidArgumentException
      *
      * @return string
      */

--- a/src/Core/Utils/Import/ImportManagerContract.php
+++ b/src/Core/Utils/Import/ImportManagerContract.php
@@ -7,8 +7,8 @@ interface ImportManagerContract
     /**
      * Get an OAuth provider implementation.
      *
-     * @param  string  $driver
-     * @return \Laravel\Socialite\Contracts\Provider
+     * @param  string|null  $driver
+     * @return mixed
      */
     public function driver($driver = null);
 }

--- a/src/Core/Utils/Import/Providers/Product.php
+++ b/src/Core/Utils/Import/Providers/Product.php
@@ -58,8 +58,8 @@ class Product extends AbstractImporter
     /**
      * Get the variant by the SKU.
      *
-     * @param [type] $sku
-     * @return void
+     * @param  string  $sku
+     * @return \GetCandy\Api\Core\Products\Models\ProductVariant
      */
     protected function getBySku($sku)
     {

--- a/src/Http/Controllers/ActivityLog/ActivityLogController.php
+++ b/src/Http/Controllers/ActivityLog/ActivityLogController.php
@@ -12,6 +12,11 @@ use Illuminate\Http\Request;
 
 class ActivityLogController extends BaseController
 {
+    /**
+     * The service mappings that can be instantiated.
+     *
+     * @var array
+     */
     protected $types = [
         'order' => OrderService::class,
         'product' => ProductService::class,
@@ -20,8 +25,9 @@ class ActivityLogController extends BaseController
     /**
      * Handle the log request.
      *
-     * @param Request $request
-     * @return void
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\ActivityLog\Interfaces\ActivityLogCriteriaInterface  $criteria
+     * @return \GetCandy\Api\Http\Resources\ActivityLog\ActivityCollection
      */
     public function index(Request $request, ActivityLogCriteriaInterface $criteria)
     {
@@ -39,7 +45,8 @@ class ActivityLogController extends BaseController
     /**
      * Store the activity log entry.
      *
-     * @param Request $request
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\ActivityLog\Interfaces\ActivityLogFactoryInterface  $factory
      * @return void
      */
     public function store(Request $request, ActivityLogFactoryInterface $factory)

--- a/src/Http/Controllers/Associations/AssociationGroupController.php
+++ b/src/Http/Controllers/Associations/AssociationGroupController.php
@@ -9,8 +9,10 @@ use Illuminate\Http\Request;
 class AssociationGroupController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of association groups.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function index(Request $request)
     {

--- a/src/Http/Controllers/Attributes/AttributeController.php
+++ b/src/Http/Controllers/Attributes/AttributeController.php
@@ -18,8 +18,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class AttributeController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of attributes.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Attributes\AttributeCollection
      */
     public function index(Request $request)
     {
@@ -42,9 +44,11 @@ class AttributeController extends BaseController
     }
 
     /**
-     * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show an attribute based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Attributes\AttributeResource
      */
     public function show($id, Request $request)
     {
@@ -59,9 +63,10 @@ class AttributeController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new attribute.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Attributes\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Attributes\AttributeResource
      */
     public function store(CreateRequest $request)
     {
@@ -84,10 +89,11 @@ class AttributeController extends BaseController
     }
 
     /**
-     * Handles the request to update  a channel.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * Handles the request to update an attribute.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Attributes\UpdateRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Attributes\AttributeResource
      */
     public function update($id, UpdateRequest $request)
     {
@@ -103,10 +109,11 @@ class AttributeController extends BaseController
     }
 
     /**
-     * Handles the request to delete a channel.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * Handles the request to delete an attribute.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Attributes\DeleteRequest  $request
+     * @return \Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Attributes/AttributeGroupController.php
+++ b/src/Http/Controllers/Attributes/AttributeGroupController.php
@@ -20,8 +20,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class AttributeGroupController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of attribute groups.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Attributes\AttributeGroupCollection
      */
     public function index(Request $request)
     {
@@ -36,9 +38,11 @@ class AttributeGroupController extends BaseController
     }
 
     /**
-     * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show an attribute group based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Attributes\AttributeGroupResource
      */
     public function show($id, Request $request)
     {
@@ -53,9 +57,10 @@ class AttributeGroupController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new attribute group.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\AttributeGroups\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Attributes\AttributeGroupResource
      */
     public function store(CreateRequest $request)
     {
@@ -66,10 +71,11 @@ class AttributeGroupController extends BaseController
     }
 
     /**
-     * Handles the request to update  a channel.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * Handles the request to update an attribute group.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\AttributeGroups\UpdateRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Attributes\AttributeGroupResource
      */
     public function update($id, UpdateRequest $request)
     {
@@ -100,10 +106,11 @@ class AttributeGroupController extends BaseController
     }
 
     /**
-     * Handles the request to delete a channel.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * Handles the request to delete an attribute group.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\AttributeGroups\DeleteRequest  $request
+     * @return \Illuminate\Http\Response
      */
     public function destroy($id, Request $request)
     {

--- a/src/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/src/Http/Controllers/Auth/ForgotPasswordController.php
@@ -36,8 +36,8 @@ class ForgotPasswordController extends BaseController
     /**
      * Send a reset link to the given user.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @param  \GetCandy\Api\Http\Requests\Auth\ForgotPasswordRequest  $request
+     * @return array
      */
     public function sendResetLinkEmail(ForgotPasswordRequest $request)
     {
@@ -51,8 +51,8 @@ class ForgotPasswordController extends BaseController
     /**
      * Get a users reset token.
      *
-     * @param string $email
-     * @return void
+     * @param  string  $email
+     * @return string
      */
     protected function getPasswordResetToken($email)
     {
@@ -69,7 +69,7 @@ class ForgotPasswordController extends BaseController
      * Get the response for a successful password reset link.
      *
      * @param  string  $response
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return array
      */
     protected function sendResetLinkResponse($token)
     {
@@ -79,9 +79,9 @@ class ForgotPasswordController extends BaseController
     /**
      * Get the response for a failed password reset link.
      *
-     * @param  \Illuminate\Http\Request
-     * @param  string  $response
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @param  \GetCandy\Api\Http\Requests\Auth\ForgotPasswordRequest  $request
+     * @param  mixed  $response
+     * @return array
      */
     protected function sendResetLinkFailedResponse(ForgotPasswordRequest $request, $response)
     {

--- a/src/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/Auth/ResetPasswordController.php
@@ -25,8 +25,8 @@ class ResetPasswordController extends BaseController
     /**
      * Reset the given user's password.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @param  \GetCandy\Api\Http\Requests\Auth\ResetPasswordRequest  $request
+     * @return array
      */
     public function reset(ResetPasswordRequest $request)
     {
@@ -52,7 +52,7 @@ class ResetPasswordController extends BaseController
      * Get the response for a successful password reset.
      *
      * @param  string  $response
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return array
      */
     protected function sendResetResponse($response)
     {
@@ -62,9 +62,9 @@ class ResetPasswordController extends BaseController
     /**
      * Get the response for a failed password reset.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  \GetCandy\Api\Http\Requests\Auth\ResetPasswordRequest  $request
      * @param  string  $response
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return array
      */
     protected function sendResetFailedResponse(ResetPasswordRequest $request, $response)
     {

--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -15,8 +15,8 @@ class BaseController extends Controller
     /**
      * Parses included fields into an array.
      *
-     * @param string $request
-     * @return void
+     * @param  mixed  $request
+     * @return string[]
      */
     protected function parseIncludedFields($request)
     {

--- a/src/Http/Controllers/Baskets/BasketController.php
+++ b/src/Http/Controllers/Baskets/BasketController.php
@@ -23,12 +23,12 @@ use Illuminate\Http\Request;
 class BasketController extends BaseController
 {
     /**
-     * @var BasketCriteria
+     * @var \GetCandy\Api\Core\Baskets\Interfaces\BasketCriteriaInterface
      */
     protected $baskets;
 
     /**
-     * @var BasketFactory
+     * @var \GetCandy\Api\Core\Baskets\Factories\BasketFactory
      */
     protected $factory;
 
@@ -39,8 +39,10 @@ class BasketController extends BaseController
     }
 
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of baskets.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketCollection
      */
     public function index(Request $request)
     {
@@ -50,9 +52,10 @@ class BasketController extends BaseController
     }
 
     /**
-     * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show a basket based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @return array|\GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function show($id)
     {
@@ -67,9 +70,10 @@ class BasketController extends BaseController
 
     /**
      * Handles the request to add meta data to a basket.
-     * @param  string $id
-     * @param  AddMetaRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Baskets\AddMetaRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function addMeta($id, AddMetaRequest $request)
     {
@@ -87,10 +91,10 @@ class BasketController extends BaseController
     /**
      * Handle the request to add a discount to a basket.
      *
-     * @param string $basketId
-     * @param AddDiscountRequest $request
-     * @param DiscountService $discounts
-     * @return BasketResource
+     * @param  string  $basketId
+     * @param  \GetCandy\Api\Http\Requests\Baskets\AddDiscountRequest  $request
+     * @param  \GetCandy\Api\Core\Discounts\Services\DiscountService  $discounts
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function addDiscount($basketId, AddDiscountRequest $request, DiscountService $discounts)
     {
@@ -122,9 +126,8 @@ class BasketController extends BaseController
     /**
      * Store either a new or existing basket.
      *
-     * @param CreateRequest $request
-     *
-     * @return void
+     * @param  \GetCandy\Api\Http\Requests\Baskets\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function store(CreateRequest $request)
     {
@@ -140,8 +143,9 @@ class BasketController extends BaseController
     /**
      * Saves a basket to a users account.
      *
-     * @param Request $request
-     * @return void
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Baskets\SaveRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function save($id, SaveRequest $request)
     {
@@ -151,10 +155,10 @@ class BasketController extends BaseController
     }
 
     /**
-     * Handle the request to get a users saved baskets.
+     * Handle the request to get a user's saved baskets.
      *
-     * @param Request $request
-     * @return void
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\SavedBasketCollection
      */
     public function saved(Request $request)
     {
@@ -166,9 +170,9 @@ class BasketController extends BaseController
     /**
      * Handle the request to delete a basket.
      *
-     * @param string $id
-     * @param DeleteRequest $request
-     * @return void
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Baskets\DeleteRequest  $request
+     * @return array
      */
     public function destroy($id, DeleteRequest $request)
     {
@@ -180,10 +184,12 @@ class BasketController extends BaseController
     /**
      * Associate a user to a basket request.
      *
-     * @param PutUserRequest $request
+     * @param  string  $basketId
+     * @param  \GetCandy\Api\Http\Requests\Baskets\PutUserRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Baskets\BasketResource
+     * 
      * @deprecated 0.2.39
      * @deprecated Use claim instead, this function will be removed in 0.3.0
-     * @return void
      */
     public function putUser($basketId, PutUserRequest $request)
     {
@@ -200,9 +206,9 @@ class BasketController extends BaseController
     /**
      * Associate a user to a basket request.
      *
-     * @param ClaimBasketRequest $request
-     *
-     * @return void
+     * @param  string  $basketId
+     * @param  \GetCandy\Api\Http\Requests\Baskets\ClaimBasketRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function claim($basketId, ClaimBasketRequest $request)
     {
@@ -229,8 +235,8 @@ class BasketController extends BaseController
     /**
      * Gets the basket for the current user.
      *
-     * @param Request $request
-     * @return void
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function current(Request $request)
     {
@@ -245,8 +251,8 @@ class BasketController extends BaseController
     /**
      * Handle the request to resolve a users basket.
      *
-     * @param Request $request
-     * @return void
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function resolve(Request $request)
     {

--- a/src/Http/Controllers/Baskets/BasketLineController.php
+++ b/src/Http/Controllers/Baskets/BasketLineController.php
@@ -15,12 +15,12 @@ use Illuminate\Support\Facades\Request;
 class BasketLineController extends BaseController
 {
     /**
-     * @var BasketLineFactory
+     * @var \GetCandy\Api\Core\Baskets\Factories\BasketLineFactory
      */
     protected $factory;
 
     /**
-     * @var BasketLineService
+     * @var \GetCandy\Api\Core\Baskets\Services\BasketLineService
      */
     protected $basketLines;
 
@@ -34,9 +34,8 @@ class BasketLineController extends BaseController
     /**
      * Store one or more new basket lines, and associate them with a basket ID.
      *
-     * @param CreateLinesRequest $request
-     *
-     * @return array|BasketResource
+     * @param  \GetCandy\Api\Http\Requests\Baskets\CreateLinesRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function store(CreateLinesRequest $request)
     {
@@ -52,10 +51,9 @@ class BasketLineController extends BaseController
     /**
      * Update a basket line's quantity.
      *
-     * @param string $id
-     * @param UpdateLineRequest $request
-     *
-     * @return BasketResource
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Baskets\UpdateLineRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function update(string $id, UpdateLineRequest $request)
     {
@@ -67,10 +65,9 @@ class BasketLineController extends BaseController
     /**
      * Increase a basketLine's quantity.
      *
-     * @param string $id
-     * @param ChangeQuantityRequest $request
-     *
-     * @return BasketResource
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Baskets\ChangeQuantityRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function addQuantity(string $id, ChangeQuantityRequest $request)
     {
@@ -84,10 +81,9 @@ class BasketLineController extends BaseController
     /**
      * Decrease a basketLine's quantity.
      *
-     * @param string $id
-     * @param ChangeQuantityRequest $request
-     *
-     * @return BasketResource
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Baskets\ChangeQuantityRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function removeQuantity(string $id, ChangeQuantityRequest $request)
     {
@@ -101,9 +97,8 @@ class BasketLineController extends BaseController
     /**
      * Handle the request to delete a basket.
      *
-     * @param DeleteLinesRequest $request
-     *
-     * @return BasketResource
+     * @param  \GetCandy\Api\Http\Requests\Baskets\DeleteLinesRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Baskets\BasketResource
      */
     public function destroy(DeleteLinesRequest $request)
     {

--- a/src/Http/Controllers/Baskets/SavedBasketController.php
+++ b/src/Http/Controllers/Baskets/SavedBasketController.php
@@ -11,9 +11,9 @@ class SavedBasketController extends BaseController
     /**
      * Handle the request to update a saved basket.
      *
-     * @param string $id
-     * @param Request $request
-     * @return void
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function update($id, Request $request)
     {

--- a/src/Http/Controllers/Categories/CategoryController.php
+++ b/src/Http/Controllers/Categories/CategoryController.php
@@ -22,6 +22,9 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CategoryController extends BaseController
 {
+    /**
+     * @var \GetCandy\Api\Core\Categories\Services\CategoryService
+     */
     protected $service;
 
     public function __construct(CategoryService $service)
@@ -117,11 +120,9 @@ class CategoryController extends BaseController
 
     /**
      * Create new category from basic information.
-     * @param $request
-     * @request String name
-     * @request String slug
-     * @request String parent_id (Optional)
-     * @return array|\Illuminate\Http\Response
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Categories\CreateRequest  $request
+     * @return array|\Illuminate\Http\JsonResponse
      */
     public function store(CreateRequest $request)
     {
@@ -146,11 +147,9 @@ class CategoryController extends BaseController
 
     /**
      * Handles the request to reorder the categories.
-     * @param $request
-     * @request String id
-     * @request String siblings
-     * @request String parent_id (Optional)
-     * @return array \Illuminate\Http\Response
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Categories\ReorderRequest  $request
+     * @return array|\Illuminate\Http\JsonResponse
      */
     public function reorder(ReorderRequest $request)
     {
@@ -173,10 +172,11 @@ class CategoryController extends BaseController
     }
 
     /**
-     * Handles the request to update  a channel.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * Handles the request to update a category.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Categories\UpdateRequest  $request
+     * @return array
      */
     public function update($id, UpdateRequest $request)
     {
@@ -241,9 +241,10 @@ class CategoryController extends BaseController
 
     /**
      * Handles the request to delete a category.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, Request $request)
     {

--- a/src/Http/Controllers/Categories/CategoryRouteController.php
+++ b/src/Http/Controllers/Categories/CategoryRouteController.php
@@ -9,10 +9,9 @@ use GetCandy\Api\Http\Resources\Routes\RouteResource;
 class CategoryRouteController extends BaseController
 {
     /**
-     * @param                                                       $product
-     * @param \GetCandy\Api\Http\Requests\Products\CreateUrlRequest $request
-     *
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     * @param  string  $category
+     * @param  \GetCandy\Api\Http\Requests\Categories\Routes\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Routes\RouteResource
      */
     public function store($category, CreateRequest $request)
     {

--- a/src/Http/Controllers/Categories/LayoutController.php
+++ b/src/Http/Controllers/Categories/LayoutController.php
@@ -11,8 +11,9 @@ class LayoutController extends BaseController
     /**
      * Handle the request to store a layout against a category.
      *
-     * @param AttachRequest $request
-     * @return json
+     * @param  string  $category
+     * @param  \GetCandy\Api\Http\Requests\Layouts\AttachRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Categories\CategoryResource
      */
     public function store($category, AttachRequest $request)
     {

--- a/src/Http/Controllers/Channels/ChannelController.php
+++ b/src/Http/Controllers/Channels/ChannelController.php
@@ -18,7 +18,9 @@ class ChannelController extends BaseController
 {
     /**
      * Returns a listing of channels.
-     * @return Json
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Channels\ChannelCollection
      */
     public function index(Request $request)
     {
@@ -29,8 +31,9 @@ class ChannelController extends BaseController
 
     /**
      * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * 
+     * @param  string  $id
+     * @return array|\GetCandy\Api\Http\Resources\Channels\ChannelResource
      */
     public function show($id)
     {
@@ -45,8 +48,9 @@ class ChannelController extends BaseController
 
     /**
      * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Channels\CreateRequest  $request
+     * @return array
      */
     public function store(CreateRequest $request)
     {
@@ -57,9 +61,10 @@ class ChannelController extends BaseController
 
     /**
      * Handles the request to update  a channel.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Channels\UpdateRequest  $request
+     * @return array
      */
     public function update($id, UpdateRequest $request)
     {
@@ -76,9 +81,10 @@ class ChannelController extends BaseController
 
     /**
      * Handles the request to delete a channel.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Channels\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Collections/CollectionController.php
+++ b/src/Http/Controllers/Collections/CollectionController.php
@@ -19,6 +19,9 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CollectionController extends BaseController
 {
+    /**
+     * @var \GetCandy\Api\Core\Collections\Services\CollectionService
+     */
     protected $service;
 
     public function __construct(CollectionService $service)
@@ -27,8 +30,11 @@ class CollectionController extends BaseController
     }
 
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of collections.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\Collections\Criteria\CollectionCriteria  $criteria
+     * @return \GetCandy\Api\Http\Resources\Collections\CollectionCollection
      */
     public function index(Request $request, CollectionCriteria $criteria)
     {
@@ -40,9 +46,12 @@ class CollectionController extends BaseController
     }
 
     /**
-     * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show a collection based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\Collections\Criteria\CollectionCriteria  $criteria
+     * @return array|\GetCandy\Api\Http\Resources\Collections\CollectionResource
      */
     public function show($id, Request $request, CollectionCriteria $criteria)
     {
@@ -85,9 +94,10 @@ class CollectionController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new collection.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Collections\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Collections\CollectionResource
      */
     public function store(CreateRequest $request)
     {
@@ -97,10 +107,11 @@ class CollectionController extends BaseController
     }
 
     /**
-     * Handles the request to update  a channel.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * Handles the request to update a collection.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Collections\UpdateRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Collections\CollectionResource
      */
     public function update($id, UpdateRequest $request)
     {
@@ -127,10 +138,11 @@ class CollectionController extends BaseController
     }
 
     /**
-     * Handles the request to delete a channel.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * Handles the request to delete a collection.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Collections\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Collections/CollectionProductController.php
+++ b/src/Http/Controllers/Collections/CollectionProductController.php
@@ -9,10 +9,9 @@ use GetCandy\Api\Http\Transformers\Fractal\Collections\CollectionTransformer;
 class CollectionProductController extends BaseController
 {
     /**
-     * @param                                                       $product
-     * @param \GetCandy\Api\Http\Requests\Products\CreateUrlRequest $request
-     *
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     * @param  string  $collection
+     * @param  \GetCandy\Api\Http\Requests\Collections\Products\UpdateRequest  $request
+     * @return array
      */
     public function store($collection, UpdateRequest $request)
     {

--- a/src/Http/Controllers/Collections/CollectionRouteController.php
+++ b/src/Http/Controllers/Collections/CollectionRouteController.php
@@ -8,10 +8,9 @@ use GetCandy\Api\Http\Requests\Collections\Routes\CreateRequest;
 class CollectionRouteController extends BaseController
 {
     /**
-     * @param                                                       $product
-     * @param \GetCandy\Api\Http\Requests\Products\CreateUrlRequest $request
-     *
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     * @param  string  $collection
+     * @param  \GetCandy\Api\Http\Requests\Collections\Routes\CreateRequest  $request
+     * @return \Illuminate\Http\Response
      */
     public function store($collection, CreateRequest $request)
     {

--- a/src/Http/Controllers/Countries/CountryController.php
+++ b/src/Http/Controllers/Countries/CountryController.php
@@ -9,8 +9,10 @@ use Illuminate\Http\Request;
 class CountryController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of countries.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function index(Request $request)
     {

--- a/src/Http/Controllers/Currencies/CurrencyController.php
+++ b/src/Http/Controllers/Currencies/CurrencyController.php
@@ -16,7 +16,9 @@ class CurrencyController extends BaseController
 {
     /**
      * Returns a listing of currencies.
-     * @return Json
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function index(Request $request)
     {
@@ -27,8 +29,9 @@ class CurrencyController extends BaseController
 
     /**
      * Handles the request to show a currency based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * 
+     * @param  string  $code
+     * @return array
      */
     public function show($code)
     {
@@ -42,9 +45,10 @@ class CurrencyController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new currency.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Currencies\CreateRequest  $request
+     * @return array
      */
     public function store(CreateRequest $request)
     {
@@ -68,9 +72,10 @@ class CurrencyController extends BaseController
 
     /**
      * Handles the request to delete a currency.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Currencies\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Customers/CustomerController.php
+++ b/src/Http/Controllers/Customers/CustomerController.php
@@ -14,7 +14,8 @@ class CustomerController extends BaseController
     /**
      * Shows all the customers.
      *
-     * @return array
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Users\UserCollection
      */
     public function index(Request $request)
     {
@@ -38,8 +39,7 @@ class CustomerController extends BaseController
     /**
      * Handles request to store a customer.
      *
-     * @param CreateRequest $request
-     *
+     * @param  \GetCandy\Api\Http\Requests\Customers\CreateRequest  $request
      * @return array
      */
     public function store(CreateRequest $request)

--- a/src/Http/Controllers/Discounts/DiscountController.php
+++ b/src/Http/Controllers/Discounts/DiscountController.php
@@ -41,9 +41,9 @@ class DiscountController extends BaseController
     /**
      * Shows the discount resource.
      *
-     * @param string $id
-     *
-     * @return void
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\Discounts\DiscountResource
      */
     public function show($id, Request $request)
     {

--- a/src/Http/Controllers/Languages/LanguageController.php
+++ b/src/Http/Controllers/Languages/LanguageController.php
@@ -17,8 +17,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class LanguageController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of languages.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Languages\LanguageCollection
      */
     public function index(Request $request)
     {
@@ -29,7 +31,9 @@ class LanguageController extends BaseController
 
     /**
      * Returns a single Language.
-     * @return Json
+     * 
+     * @param  string  $id
+     * @return array
      */
     public function show($id)
     {
@@ -44,8 +48,9 @@ class LanguageController extends BaseController
 
     /**
      * Handles the request to create a new language.
-     * @param  CreateRequest $request
-     * @return Json
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Languages\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Languages\LanguageResource
      */
     public function store(CreateRequest $request)
     {
@@ -55,10 +60,11 @@ class LanguageController extends BaseController
     }
 
     /**
-     * Handles the request to update  a language.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * Handles the request to update a language.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Languages\UpdateRequest  $request
+     * @return array
      */
     public function update($id, UpdateRequest $request)
     {
@@ -75,9 +81,10 @@ class LanguageController extends BaseController
 
     /**
      * Handles the request to delete a language.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Languages\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Layouts/LayoutController.php
+++ b/src/Http/Controllers/Layouts/LayoutController.php
@@ -19,8 +19,9 @@ class LayoutController extends BaseController
 
     /**
      * Handles the request to show a layout based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * 
+     * @param  string  $id
+     * @return array
      */
     public function show($id)
     {

--- a/src/Http/Controllers/Orders/OrderController.php
+++ b/src/Http/Controllers/Orders/OrderController.php
@@ -35,12 +35,13 @@ use Illuminate\Http\Request;
 
 class OrderController extends BaseController
 {
+    /**
+     * @var \GetCandy\Api\Core\Orders\Interfaces\OrderCriteriaInterface
+     */
     protected $orders;
 
     /**
-     * The baskets criteria instance.
-     *
-     * @var BasketCriteriaInterface
+     * @var \GetCandy\Api\Core\Baskets\Interfaces\BasketCriteriaInterface
      */
     protected $baskets;
 
@@ -53,8 +54,10 @@ class OrderController extends BaseController
     }
 
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of orders.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Orders\OrderCollection
      */
     public function index(Request $request)
     {
@@ -120,9 +123,11 @@ class OrderController extends BaseController
     }
 
     /**
-     * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show an order based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function show($id, Request $request)
     {
@@ -141,9 +146,10 @@ class OrderController extends BaseController
     /**
      * Store either a new or existing basket.
      *
-     * @param CreateRequest $request
-     *
-     * @return void
+     * @param  \GetCandy\Api\Http\Requests\Orders\CreateRequest  $request
+     * @param  \GetCandy\Api\Core\Orders\Interfaces\OrderFactoryInterface  $factory
+     * @param  \GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface  $basketFactory
+     * @return \GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function store(CreateRequest $request, OrderFactoryInterface $factory, BasketFactoryInterface $basketFactory)
     {
@@ -162,9 +168,13 @@ class OrderController extends BaseController
     /**
      * Process an order.
      *
-     * @param ProcessRequest $request
-     *
-     * @return json
+     * @param  \GetCandy\Api\Http\Requests\Orders\ProcessRequest  $request
+     * @param  \GetCandy\Api\Core\Orders\Interfaces\OrderProcessingFactoryInterface  $factory
+     * @param  \GetCandy\Api\Core\Orders\Interfaces\OrderCriteriaInterface  $criteria
+     * @param  \GetCandy\Api\Core\Payments\Services\PaymentTypeService  $paymentTypes
+     * @return array|\GetCandy\Api\Http\Resources\Orders\OrderResource|\GetCandy\Api\Http\Resources\Payments\ThreeDSecureResource
+     * 
+     * @throws \GetCandy\Api\Core\Orders\Exceptions\OrderAlreadyProcessedException
      */
     public function process(
         ProcessRequest $request,
@@ -242,9 +252,8 @@ class OrderController extends BaseController
     /**
      * Expire an order.
      *
-     * @param ExpireRequest $request
-     *
-     * @return json
+     * @param  string  $id
+     * @return array|\Illuminate\Http\Response
      */
     public function expire($id)
     {
@@ -260,10 +269,9 @@ class OrderController extends BaseController
     /**
      * Set the shipping address of an order.
      *
-     * @param string $id
-     * @param StoreAddressRequest $request
-     *
-     * @return array
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Orders\StoreAddressRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function shippingAddress($id, StoreAddressRequest $request)
     {
@@ -279,10 +287,9 @@ class OrderController extends BaseController
     /**
      * Update an order.
      *
-     * @param string $id
-     * @param Request $request
-     *
-     * @return array
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Orders\UpdateRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function update($id, UpdateRequest $request)
     {
@@ -298,10 +305,10 @@ class OrderController extends BaseController
     /**
      * Get shipping methods for an order.
      *
-     * @param string $orderId
-     * @param Request $request
-     *
-     * @return array
+     * @param  string  $orderId
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\Shipping\Services\ShippingMethodService $methods
+     * @return array|\GetCandy\Api\Http\Resources\Shipping\ShippingPriceCollection
      */
     public function shippingMethods($orderId, Request $request, ShippingMethodService $methods)
     {
@@ -317,10 +324,9 @@ class OrderController extends BaseController
     /**
      * Add a contact to an order.
      *
-     * @param string $orderId
-     * @param Request $request
-     *
-     * @return array
+     * @param  string  $orderId
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function addContact($orderId, Request $request)
     {
@@ -341,10 +347,9 @@ class OrderController extends BaseController
     /**
      * Set an orders billing address.
      *
-     * @param string $id
-     * @param StoreAddressRequest $request
-     *
-     * @return array
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Orders\StoreAddressRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function billingAddress($id, StoreAddressRequest $request)
     {
@@ -360,10 +365,12 @@ class OrderController extends BaseController
     /**
      * Set shipping cost of an order.
      *
-     * @param string $id
-     * @param Request $request
-     *
-     * @return array
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Orders\Shipping\AddShippingRequest  $request
+     * @param  \GetCandy\Api\Core\Orders\Interfaces\OrderFactoryInterface  $factory
+     * @param  \GetCandy\Api\Core\Shipping\Services\ShippingPriceService  $prices
+     * @param  \GetCandy\Api\Core\Baskets\Interfaces\BasketFactoryInterface  $basketFactory
+     * @return \GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function shippingCost(
         $id,
@@ -387,10 +394,9 @@ class OrderController extends BaseController
     /**
      * Get the invoice PDF.
      *
-     * @param string $id
-     * @param Request $request
-     *
-     * @return mixed
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\Files\PdfResource
      */
     public function invoice($id, Request $request)
     {
@@ -409,9 +415,9 @@ class OrderController extends BaseController
     /**
      * Handle the request to return an email preview.
      *
-     * @param string $status
-     * @param Request $request
-     * @return void
+     * @param  string  $status
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Http\JsonResponse
      */
     public function emailPreview($status, Request $request)
     {

--- a/src/Http/Controllers/Orders/OrderLineController.php
+++ b/src/Http/Controllers/Orders/OrderLineController.php
@@ -11,6 +11,9 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class OrderLineController extends BaseController
 {
+    /**
+     * @var \GetCandy\Api\Core\Orders\Services\OrderLineService
+     */
     protected $orderLines;
 
     public function __construct(OrderLineService $lines)
@@ -21,10 +24,9 @@ class OrderLineController extends BaseController
     /**
      * Handles the request to store a new order line.
      *
-     * @param string $orderId
-     * @param CreateRequest $request
-     * @param OrderLineService $lines
-     * @return void
+     * @param  string  $orderId
+     * @param  \GetCandy\Api\Http\Requests\Orders\Lines\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function store($orderId, CreateRequest $request)
     {
@@ -40,9 +42,9 @@ class OrderLineController extends BaseController
     /**
      * Handles the request to remove an order line.
      *
-     * @param string $lineId
-     * @param DeleteRequest $request
-     * @return void
+     * @param  string  $lineId
+     * @param  \GetCandy\Api\Http\Requests\Orders\Lines\DeleteRequest  $request
+     * @return array
      */
     public function destroy($lineId, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Pages/PageController.php
+++ b/src/Http/Controllers/Pages/PageController.php
@@ -17,9 +17,10 @@ class PageController extends BaseController
     }
 
     /**
-     * Handles the request to show a currency based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show a page based on it's hashed ID.
+     * 
+     * @param  string  $channel
+     * @return array
      */
     public function show($channel, $lang, $slug = null)
     {

--- a/src/Http/Controllers/Payments/PaymentController.php
+++ b/src/Http/Controllers/Payments/PaymentController.php
@@ -31,10 +31,9 @@ class PaymentController extends BaseController
     /**
      * Handle the request to refund a transaction.
      *
-     * @param string $id
-     * @param RefundRequest $request
-     *
-     * @return mixed
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Payments\RefundRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Transactions\TransactionResource
      */
     public function refund($id, RefundRequest $request)
     {
@@ -62,9 +61,9 @@ class PaymentController extends BaseController
     /**
      * Handle the request to void a payment.
      *
-     * @param string $id
-     * @param VoidRequest $request
-     * @return Json
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Payments\VoidRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Transactions\TransactionResource
      */
     public function void($id, VoidRequest $request)
     {
@@ -84,8 +83,8 @@ class PaymentController extends BaseController
     /**
      * Handles the request to validate a 3DSecure Transaction.
      *
-     * @param ValidateThreeDRequest $request
-     * @return void
+     * @param  \GetCandy\Api\Http\Requests\Payments\ValidateThreeDRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Orders\OrderResource
      */
     public function validateThreeD(ValidateThreeDRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductAssetController.php
+++ b/src/Http/Controllers/Products/ProductAssetController.php
@@ -12,8 +12,8 @@ class ProductAssetController extends BaseController
     /**
      * Gets all assets for a product.
      * @param  int  $id
-     * @param  Request $request
-     * @return array|\Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function index($id, Request $request)
     {
@@ -43,9 +43,10 @@ class ProductAssetController extends BaseController
 
     /**
      * Uploads an asset for a product.
-     * @param  int        $id
-     * @param  UploadRequest $request
-     * @return array|\Illuminate\Http\Response
+     * 
+     * @param  int  $id
+     * @param  \GetCandy\Api\Http\Requests\Assets\UploadRequest  $request
+     * @return void
      */
     public function upload($id, UploadRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductAssociationController.php
+++ b/src/Http/Controllers/Products/ProductAssociationController.php
@@ -10,10 +10,11 @@ use GetCandy\Api\Http\Resources\Products\ProductAssociationCollection;
 class ProductAssociationController extends BaseController
 {
     /**
-     * Handles the request to update a products attributes.
-     * @param  string        $product
-     * @param  UpdateAttributesRequest $request
-     * @return mixed
+     * Handles the request to update a products associations.
+     * 
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\Associations\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Products\ProductAssociationCollection
      */
     public function store($product, CreateRequest $request)
     {
@@ -24,9 +25,10 @@ class ProductAssociationController extends BaseController
 
     /**
      * Handles the request to remove a product association.
-     * @param  string        $product
-     * @param  DeleteRequest $request
-     * @return mixed
+     * 
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\Associations\DeleteRequest  $request
+     * @return \Illuminate\Http\Response
      */
     public function destroy($product, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductAttributeController.php
+++ b/src/Http/Controllers/Products/ProductAttributeController.php
@@ -11,9 +11,10 @@ class ProductAttributeController extends BaseController
 {
     /**
      * Handles the request to update a products attributes.
-     * @param  string        $product
-     * @param  UpdateAttributesRequest $request
-     * @return mixed
+     * 
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\UpdateAttributesRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Products\ProductResource
      */
     public function update($product, UpdateAttributesRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductCategoryController.php
+++ b/src/Http/Controllers/Products/ProductCategoryController.php
@@ -11,9 +11,10 @@ class ProductCategoryController extends BaseController
 {
     /**
      * Handles the request to update a products categories.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Products\UpdateCategoriesRequest  $request
+     * @return array
      */
     public function update($product, UpdateCategoriesRequest $request)
     {
@@ -23,10 +24,11 @@ class ProductCategoryController extends BaseController
     }
 
     /**
-     * Deletes a products category.
-     * @param  int        $productId
-     * @param  int        $categoryId
-     * @return array|\Illuminate\Http\Response
+     * Deletes a product's category.
+     * 
+     * @param  string  $productId
+     * @param  string  $categoryId
+     * @return \Illuminate\Http\JsonResponse
      */
     public function destroy($productId, $categoryId)
     {

--- a/src/Http/Controllers/Products/ProductChannelController.php
+++ b/src/Http/Controllers/Products/ProductChannelController.php
@@ -10,10 +10,12 @@ use GetCandy\Api\Http\Resources\Products\ProductResource;
 class ProductChannelController extends BaseController
 {
     /**
-     * Handles the request to update a products customer groups.
-     * @param  string        $product
-     * @param  UpdateChannelRequest $request
-     * @return mixed
+     * Handles the request to update a product's channels.
+     * 
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\UpdateChannelRequest  $request
+     * @param  \GetCandy\Api\Core\Products\Services\ProductChannelService  $service
+     * @return \GetCandy\Api\Http\Resources\Products\ProductResource
      */
     public function store($product, UpdateChannelRequest $request, ProductChannelService $service)
     {
@@ -23,10 +25,11 @@ class ProductChannelController extends BaseController
     }
 
     /**
-     * Handles the request to remove a product association.
-     * @param  string        $product
-     * @param  DeleteRequest $request
-     * @return mixed
+     * Handles the request to remove a product's channel.
+     * 
+     * @param  string  $product
+     * @param  mixed  $request (?)
+     * @return void
      */
     public function destroy($product, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductCollectionController.php
+++ b/src/Http/Controllers/Products/ProductCollectionController.php
@@ -9,9 +9,9 @@ use GetCandy\Api\Http\Transformers\Fractal\Collections\CollectionTransformer;
 class ProductCollectionController extends BaseController
 {
     /**
-     * @param $product
-     * @param UpdateCollectionsRequest $request
-     * @return array|\Illuminate\Http\Response
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\UpdateCollectionsRequest  $request
+     * @return array
      */
     public function update($product, UpdateCollectionsRequest $request)
     {
@@ -28,9 +28,10 @@ class ProductCollectionController extends BaseController
 
     /**
      * Deletes a products collection.
-     * @param  int        $productId
-     * @param  int        $collectionId
-     * @return array|\Illuminate\Http\Response
+     * 
+     * @param  string  $productId
+     * @param  string  $collectionId
+     * @return \Illuminate\Http\JsonResponse
      */
     public function destroy($productId, $collectionId)
     {

--- a/src/Http/Controllers/Products/ProductController.php
+++ b/src/Http/Controllers/Products/ProductController.php
@@ -28,9 +28,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class ProductController extends BaseController
 {
     /**
-     * The product service.
-     *
-     * @var ProductService
+     * @var \GetCandy\Api\Core\Products\Services\ProductService
      */
     protected $service;
 
@@ -41,8 +39,10 @@ class ProductController extends BaseController
 
     /**
      * Handles the request to show all products.
-     * @param  Request $request
-     * @return array
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\Products\ProductCriteria  $criteria
+     * @return \GetCandy\Api\Http\Resources\Products\ProductCollection
      */
     public function index(Request $request, ProductCriteria $criteria)
     {
@@ -64,8 +64,10 @@ class ProductController extends BaseController
 
     /**
      * Handles the request to show a product based on hashed ID.
-     * @param  string $id
-     * @return array|\Illuminate\Http\Response
+     * 
+     * @param  string  $idOrSku
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\Products\ProductResource
      */
     public function show($idOrSku, Request $request)
     {
@@ -137,7 +139,8 @@ class ProductController extends BaseController
 
     /**
      * Handles the request to create a new product.
-     * @param  CreateRequest $request
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Products\CreateRequest  $request
      * @return array
      */
     public function store(CreateRequest $request)
@@ -153,8 +156,9 @@ class ProductController extends BaseController
 
     /**
      * Handles the request to update a product.
-     * @param  string        $id
-     * @param  UpdateRequest $request
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Products\UpdateRequest  $request
      * @return array|\Illuminate\Http\Response
      */
     public function update($id, UpdateRequest $request)
@@ -194,9 +198,10 @@ class ProductController extends BaseController
 
     /**
      * Handles the request to delete a product.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Products\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductCustomerGroupController.php
+++ b/src/Http/Controllers/Products/ProductCustomerGroupController.php
@@ -10,10 +10,12 @@ use GetCandy\Api\Http\Resources\Products\ProductResource;
 class ProductCustomerGroupController extends BaseController
 {
     /**
-     * Handles the request to update a products customer groups.
-     * @param  string        $product
-     * @param  StoreCustomerGroupsRequest $request
-     * @return mixed
+     * Handles the request to update a product's customer groups.
+     * 
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\UpdateCustomerGroupsRequest  $request
+     * @param  \GetCandy\Api\Core\Products\Services\ProductCustomerGroupService  $service
+     * @return \GetCandy\Api\Http\Resources\Products\ProductResource
      */
     public function store($product, UpdateCustomerGroupsRequest $request, ProductCustomerGroupService $service)
     {
@@ -24,9 +26,10 @@ class ProductCustomerGroupController extends BaseController
 
     /**
      * Handles the request to remove a product association.
-     * @param  string        $product
-     * @param  DeleteRequest $request
-     * @return mixed
+     * 
+     * @param  string  $product
+     * @param  mixed $request (?)
+     * @return \Illuminate\Http\Response
      */
     public function destroy($product, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductFamilyController.php
+++ b/src/Http/Controllers/Products/ProductFamilyController.php
@@ -20,8 +20,9 @@ class ProductFamilyController extends BaseController
 {
     /**
      * Handles the request to show all product families.
-     * @param  Request $request
-     * @return Json
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Products\ProductFamilyCollection
      */
     public function index(Request $request)
     {
@@ -37,8 +38,11 @@ class ProductFamilyController extends BaseController
 
     /**
      * Handles the request to show a product family based on hashed ID.
-     * @param  string $id
-     * @return Json
+     *
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\Products\Criteria\ProductFamilyCriteria  $criteria
+     * @return array|\GetCandy\Api\Http\Resources\Products\ProductFamilyResource
      */
     public function show($id, Request $request, ProductFamilyCriteria $criteria)
     {
@@ -53,8 +57,9 @@ class ProductFamilyController extends BaseController
 
     /**
      * Handles the request to create a new product family.
-     * @param  CreateRequest $request
-     * @return Json
+     * 
+     * @param  \GetCandy\Api\Http\Requests\ProductFamilies\CreateRequest  $request
+     * @return array
      */
     public function store(CreateRequest $request)
     {
@@ -69,9 +74,10 @@ class ProductFamilyController extends BaseController
 
     /**
      * Handles the request to update a product family.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\ProductFamilies\UpdateRequest  $request
+     * @return array
      */
     public function update($id, UpdateRequest $request)
     {
@@ -90,9 +96,10 @@ class ProductFamilyController extends BaseController
 
     /**
      * Handles the request to delete a product family.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\ProductFamilies\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductRedirectController.php
+++ b/src/Http/Controllers/Products/ProductRedirectController.php
@@ -8,10 +8,9 @@ use GetCandy\Api\Http\Requests\Products\CreateUrlRequest;
 class ProductRedirectController extends BaseController
 {
     /**
-     * @param                                                       $product
-     * @param \GetCandy\Api\Http\Requests\Products\CreateUrlRequest $request
-     *
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\CreateUrlRequest  $request
+     * @return \Illuminate\Http\Response
      */
     public function store($product, CreateUrlRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductRouteController.php
+++ b/src/Http/Controllers/Products/ProductRouteController.php
@@ -10,10 +10,9 @@ use GetCandy\Api\Http\Resources\Routes\RouteResource;
 class ProductRouteController extends BaseController
 {
     /**
-     * @param                                                       $product
-     * @param \GetCandy\Api\Http\Requests\Products\CreateUrlRequest $request
-     *
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\Products\CreateUrlRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Routes\RouteResource
      */
     public function store($product, CreateUrlRequest $request)
     {

--- a/src/Http/Controllers/Products/ProductVariantController.php
+++ b/src/Http/Controllers/Products/ProductVariantController.php
@@ -17,9 +17,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class ProductVariantController extends BaseController
 {
     /**
-     * Handles the request to show all product families.
-     * @param  Request $request
-     * @return Json
+     * Handles the request to show all product variants.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Products\ProductVariantCollection
      */
     public function index(Request $request)
     {
@@ -29,9 +30,10 @@ class ProductVariantController extends BaseController
     }
 
     /**
-     * Handles the request to show a product family based on hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show a product variant based on hashed ID.
+     * 
+     * @param  string  $id
+     * @return array|\GetCandy\Api\Http\Resources\Products\ProductVariantResource
      */
     public function show($id)
     {
@@ -46,8 +48,10 @@ class ProductVariantController extends BaseController
 
     /**
      * Handles the request to create the variants.
-     * @param  CreateRequest $request
-     * @return Json
+     * 
+     * @param  string  $product
+     * @param  \GetCandy\Api\Http\Requests\ProductVariants\CreateRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Products\ProductResource
      */
     public function store($product, CreateRequest $request)
     {
@@ -63,10 +67,11 @@ class ProductVariantController extends BaseController
     }
 
     /**
-     * Handles the request to update a product family.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * Handles the request to update a product variant.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\ProductVariants\UpdateRequest  $request
+     * @return array|\GetCandy\Api\Http\Resources\Products\ProductVariantResource
      */
     public function update($id, UpdateRequest $request)
     {
@@ -84,10 +89,11 @@ class ProductVariantController extends BaseController
     }
 
     /**
-     * Handles the request to delete a product family.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * Handles the request to delete a product variant.
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\ProductVariants\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/RecycleBin/RecycleBinController.php
+++ b/src/Http/Controllers/RecycleBin/RecycleBinController.php
@@ -19,8 +19,9 @@ class RecycleBinController extends BaseController
 
     /**
      * Handles request to get all recycle bin items.
-     * @param  Request $request
-     * @return array|\Illuminate\Http\Response
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\RecycleBin\RecycleBinCollection
      */
     public function index(Request $request)
     {
@@ -35,8 +36,10 @@ class RecycleBinController extends BaseController
 
     /**
      * Handles request to get all recycle bin items.
-     * @param  Request $request
-     * @return array|\Illuminate\Http\Response
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\RecycleBin\RecycleBinResource
      */
     public function show($id, Request $request)
     {

--- a/src/Http/Controllers/Routes/RouteController.php
+++ b/src/Http/Controllers/Routes/RouteController.php
@@ -23,8 +23,10 @@ class RouteController extends BaseController
 
     /**
      * Handles the request to show a route based on it's hashed ID.
-     * @param  string $slug
-     * @return Json
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\Routes\RouteCriteria  $routes
+     * @return array|\GetCandy\Api\Http\Resources\Routes\RouteResource
      */
     public function show(Request $request, RouteCriteria $routes)
     {
@@ -40,10 +42,9 @@ class RouteController extends BaseController
     /**
      * Update a route.
      *
-     * @param string $id
-     * @param UpdateRequest $request
-     *
-     * @return Json
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Routes\UpdateRequest  $request
+     * @return array
      */
     public function update($id, UpdateRequest $request)
     {

--- a/src/Http/Controllers/Search/SearchController.php
+++ b/src/Http/Controllers/Search/SearchController.php
@@ -15,9 +15,7 @@ use Illuminate\Http\Request;
 class SearchController extends BaseController
 {
     /**
-     * The channel service.
-     *
-     * @var ChannelService
+     * @var \GetCandy\Api\Core\Channels\Services\ChannelService
      */
     protected $channels;
 
@@ -30,10 +28,9 @@ class SearchController extends BaseController
     /**
      * Performs a search against a type.
      *
-     * @param Request $request
-     * @param SearchContract $client
-     *
-     * @return array
+     * @param  \GetCandy\Api\Http\Requests\Search\SearchRequest  $request
+     * @param  \GetCandy\Api\Core\Search\SearchContract  $search
+     * @return array|\Illuminate\Http\Response
      */
     public function search(SearchRequest $request, SearchContract $search)
     {
@@ -95,9 +92,9 @@ class SearchController extends BaseController
     /**
      * Gets suggested searches.
      *
-     * @param SearchRequest $request
-     * @param SearchContract $client
-     * @return void
+     * @param  \GetCandy\Api\Http\Requests\Search\SearchRequest  $request
+     * @param  \GetCandy\Api\Core\Search\SearchContract  $client
+     * @return array
      */
     public function suggest(SearchRequest $request, SearchContract $client)
     {
@@ -123,9 +120,11 @@ class SearchController extends BaseController
     /**
      * Handle the request to do an SKU search.
      *
-     * @param Request $request
-     * @param SearchContract $client
-     * @return json
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \GetCandy\Api\Core\Search\SearchContract  $client
+     * @return \Illuminate\Http\JsonResponse
+     * 
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function sku(Request $request, SearchContract $client)
     {

--- a/src/Http/Controllers/Settings/SettingController.php
+++ b/src/Http/Controllers/Settings/SettingController.php
@@ -16,9 +16,10 @@ class SettingController extends BaseController
     }
 
     /**
-     * Handles the request to show a route based on it's hashed ID.
-     * @param  string $slug
-     * @return Json
+     * Handles the request to show a setting based on it's hashed ID.
+     * 
+     * @param  string  $handle
+     * @return array|\GetCandy\Api\Http\Resources\Settings\SettingResource
      */
     public function show($handle)
     {

--- a/src/Http/Controllers/Shipping/ShippingMethodController.php
+++ b/src/Http/Controllers/Shipping/ShippingMethodController.php
@@ -15,8 +15,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class ShippingMethodController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of shipping methods.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Shipping\ShippingMethodCollection
      */
     public function index(Request $request)
     {
@@ -27,8 +29,10 @@ class ShippingMethodController extends BaseController
 
     /**
      * Handles the request to show a shipping method based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\Shipping\ShippingMethodResource
      */
     public function show($id, Request $request)
     {
@@ -42,9 +46,10 @@ class ShippingMethodController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new shipping method.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Shipping\CreateRequest  $request
+     * @return array
      */
     public function store(CreateRequest $request)
     {

--- a/src/Http/Controllers/Shipping/ShippingPriceController.php
+++ b/src/Http/Controllers/Shipping/ShippingPriceController.php
@@ -13,8 +13,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class ShippingPriceController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of shipping prices.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function index(Request $request)
     {
@@ -24,9 +26,10 @@ class ShippingPriceController extends BaseController
     }
 
     /**
-     * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show a shipping price based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @return array
      */
     public function show($id)
     {
@@ -40,9 +43,10 @@ class ShippingPriceController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new shipping price.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Shipping\Pricing\StoreRequest  $request
+     * @return array
      */
     public function store($id, StoreRequest $request)
     {
@@ -70,10 +74,10 @@ class ShippingPriceController extends BaseController
     }
 
     /**
-     * Handles the request to delete a channel.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * Handles the request to delete a shipping price.
+     * 
+     * @param  string  $id
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id)
     {

--- a/src/Http/Controllers/Shipping/ShippingZoneController.php
+++ b/src/Http/Controllers/Shipping/ShippingZoneController.php
@@ -14,8 +14,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class ShippingZoneController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of shipping zones.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Shipping\ShippingZoneCollection
      */
     public function index(Request $request)
     {
@@ -29,9 +31,11 @@ class ShippingZoneController extends BaseController
     }
 
     /**
-     * Handles the request to show a channel based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show a shipping zone based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\GetCandy\Api\Http\Resources\Shipping\ShippingZoneResource
      */
     public function show($id, Request $request)
     {
@@ -45,9 +49,10 @@ class ShippingZoneController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new shipping zone.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Shipping\Zones\CreateRequest  $request
+     * @return \GetCandy\Api\Http\Resources\Shipping\ShippingZoneResource
      */
     public function store(CreateRequest $request)
     {

--- a/src/Http/Controllers/Tags/TagController.php
+++ b/src/Http/Controllers/Tags/TagController.php
@@ -12,8 +12,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class TagController extends BaseController
 {
     /**
-     * Returns a listing of channels.
-     * @return Json
+     * Returns a listing of tags.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \GetCandy\Api\Http\Resources\Tags\TagCollection
      */
     public function index(Request $request)
     {
@@ -24,8 +26,9 @@ class TagController extends BaseController
 
     /**
      * Handles the request to show a tag based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * 
+     * @param  string  $id
+     * @return array
      */
     public function show($id)
     {
@@ -40,8 +43,9 @@ class TagController extends BaseController
 
     /**
      * Handles the request to create a new tag.
-     * @param  CreateRequest $request
-     * @return Json
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function store(Request $request)
     {
@@ -52,9 +56,10 @@ class TagController extends BaseController
 
     /**
      * Handles the request to update a tag.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  mixed  $request (?)
+     * @return array
      */
     public function update($id, UpdateRequest $request)
     {
@@ -71,9 +76,10 @@ class TagController extends BaseController
 
     /**
      * Handles the request to delete a tag.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  mixed  $request (?)
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Taxes/TaxController.php
+++ b/src/Http/Controllers/Taxes/TaxController.php
@@ -15,8 +15,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class TaxController extends BaseController
 {
     /**
-     * Returns a listing of currencies.
-     * @return Json
+     * Returns a listing of taxes.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function index(Request $request)
     {
@@ -26,9 +28,10 @@ class TaxController extends BaseController
     }
 
     /**
-     * Handles the request to show a currency based on it's hashed ID.
-     * @param  string $id
-     * @return Json
+     * Handles the request to show a tax based on it's hashed ID.
+     * 
+     * @param  string  $id
+     * @return array
      */
     public function show($id)
     {
@@ -42,9 +45,10 @@ class TaxController extends BaseController
     }
 
     /**
-     * Handles the request to create a new channel.
-     * @param  CreateRequest $request
-     * @return Json
+     * Handles the request to create a new tax.
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Taxes\CreateRequest  $request
+     * @return array
      */
     public function store(CreateRequest $request)
     {
@@ -55,9 +59,10 @@ class TaxController extends BaseController
 
     /**
      * Handles the request to update taxes.
-     * @param  string        $id
-     * @param  UpdateRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Taxes\UpdateRequest  $request
+     * @return array
      */
     public function update($id, UpdateRequest $request)
     {
@@ -74,9 +79,10 @@ class TaxController extends BaseController
 
     /**
      * Handles the request to delete a tax.
-     * @param  string        $id
-     * @param  DeleteRequest $request
-     * @return Json
+     * 
+     * @param  string  $id
+     * @param  \GetCandy\Api\Http\Requests\Taxes\DeleteRequest  $request
+     * @return array|\Illuminate\Http\Response
      */
     public function destroy($id, DeleteRequest $request)
     {

--- a/src/Http/Controllers/Users/UserController.php
+++ b/src/Http/Controllers/Users/UserController.php
@@ -13,6 +13,9 @@ use Illuminate\Http\Request;
 
 class UserController extends BaseController
 {
+    /**
+     * @var \GetCandy\Api\Core\Users\Contracts\UserContract
+     */
     protected $users;
 
     public function __construct(UserContract $users)
@@ -22,7 +25,9 @@ class UserController extends BaseController
 
     /**
      * Handles the request to show a listing of all users.
-     * @return Json
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
     public function index(Request $request)
     {
@@ -38,8 +43,9 @@ class UserController extends BaseController
 
     /**
      * Handles the request to show a user based on their hashed ID.
-     * @param  string $id
-     * @return Json
+     * 
+     * @param  string  $id
+     * @return array
      */
     public function show($id)
     {
@@ -54,8 +60,9 @@ class UserController extends BaseController
 
     /**
      * Handles the request to create a new user.
-     * @param  CreateUserRequest $request
-     * @return Json
+     * 
+     * @param  \GetCandy\Api\Http\Requests\Users\CreateRequest  $request
+     * @return array
      */
     public function store(CreateRequest $request)
     {
@@ -105,8 +112,8 @@ class UserController extends BaseController
     /**
      * Get the configured fields for a user.
      *
-     * @param Request $request
-     * @return json
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
      */
     public function fields(Request $request)
     {

--- a/src/Http/Middleware/DetectHubRequestMiddleware.php
+++ b/src/Http/Middleware/DetectHubRequestMiddleware.php
@@ -7,6 +7,9 @@ use GetCandy;
 
 class DetectHubRequestMiddleware
 {
+    /**
+     * @var \GetCandy\Api\Core\GetCandy
+     */
     protected $api;
 
     public function __construct(GetCandy $api)

--- a/src/Http/Middleware/SetChannelMiddleware.php
+++ b/src/Http/Middleware/SetChannelMiddleware.php
@@ -8,9 +8,7 @@ use GetCandy\Api\Core\Channels\Interfaces\ChannelFactoryInterface;
 class SetChannelMiddleware
 {
     /**
-     * The channel factory interface.
-     *
-     * @var ChannelFactoryInterface
+     * @var \GetCandy\Api\Core\Channels\Interfaces\ChannelFactoryInterface
      */
     protected $channel;
 

--- a/src/Http/Middleware/SetCurrencyMiddleware.php
+++ b/src/Http/Middleware/SetCurrencyMiddleware.php
@@ -8,9 +8,7 @@ use GetCandy\Api\Core\Currencies\Interfaces\CurrencyConverterInterface;
 class SetCurrencyMiddleware
 {
     /**
-     * The Currency converter instance.
-     *
-     * @var CurrencyConverterInterface
+     * @var \GetCandy\Api\Core\Currencies\Interfaces\CurrencyConverterInterface
      */
     protected $converter;
 

--- a/src/Http/Middleware/SetTaxMiddleware.php
+++ b/src/Http/Middleware/SetTaxMiddleware.php
@@ -8,9 +8,7 @@ use GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface;
 class SetTaxMiddleware
 {
     /**
-     * The tax calculator instance.
-     *
-     * @var TaxCalculatorInterface
+     * @var \GetCandy\Api\Core\Taxes\Interfaces\TaxCalculatorInterface
      */
     protected $tax;
 

--- a/src/Http/Requests/Assets/DeleteRequest.php
+++ b/src/Http/Requests/Assets/DeleteRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('delete', Attribute::class);
         return true;
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Assets/UpdateAllRequest.php
+++ b/src/Http/Requests/Assets/UpdateAllRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateAllRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('delete', Attribute::class);
         return true;
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Assets/UploadRequest.php
+++ b/src/Http/Requests/Assets/UploadRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UploadRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Attribute::class);
         return true;
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/AttributeGroups/CreateRequest.php
+++ b/src/Http/Requests/AttributeGroups/CreateRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class CreateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Attribute::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/AttributeGroups/DeleteRequest.php
+++ b/src/Http/Requests/AttributeGroups/DeleteRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Attribute::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/AttributeGroups/ReorderRequest.php
+++ b/src/Http/Requests/AttributeGroups/ReorderRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class ReorderRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', AttributeGroup::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [
@@ -20,6 +30,11 @@ class ReorderRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/AttributeGroups/UpdateRequest.php
+++ b/src/Http/Requests/AttributeGroups/UpdateRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('update', AttributeGroup::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         $service = app('api')->attributeGroups();

--- a/src/Http/Requests/Attributes/CreateRequest.php
+++ b/src/Http/Requests/Attributes/CreateRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class CreateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Attribute::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules(Attribute $attribute)
     {
         return [

--- a/src/Http/Requests/Attributes/DeleteRequest.php
+++ b/src/Http/Requests/Attributes/DeleteRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('delete', Attribute::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Attributes/ReorderRequest.php
+++ b/src/Http/Requests/Attributes/ReorderRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class ReorderRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', AttributeGroup::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [
@@ -20,6 +30,11 @@ class ReorderRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Attributes/UpdateRequest.php
+++ b/src/Http/Requests/Attributes/UpdateRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('update', AttributeGroup::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         $decodedId = app('api')->attributes()->getDecodedId($this->attribute);

--- a/src/Http/Requests/Baskets/AddDiscountRequest.php
+++ b/src/Http/Requests/Baskets/AddDiscountRequest.php
@@ -29,6 +29,11 @@ class AddDiscountRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Baskets/AddMetaRequest.php
+++ b/src/Http/Requests/Baskets/AddMetaRequest.php
@@ -29,6 +29,11 @@ class AddMetaRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Baskets/CreateLinesRequest.php
+++ b/src/Http/Requests/Baskets/CreateLinesRequest.php
@@ -45,6 +45,11 @@ class CreateLinesRequest extends FormRequest
         return $rules;
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Baskets/CreateRequest.php
+++ b/src/Http/Requests/Baskets/CreateRequest.php
@@ -46,6 +46,11 @@ class CreateRequest extends FormRequest
         return $rules;
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Baskets/DeleteLinesRequest.php
+++ b/src/Http/Requests/Baskets/DeleteLinesRequest.php
@@ -16,6 +16,11 @@ class DeleteLinesRequest extends FormRequest
         return true;
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Baskets/DeleteRequest.php
+++ b/src/Http/Requests/Baskets/DeleteRequest.php
@@ -19,6 +19,11 @@ class DeleteRequest extends FormRequest
         return $basket->user->id == $this->user()->id;
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [];

--- a/src/Http/Requests/Baskets/SaveRequest.php
+++ b/src/Http/Requests/Baskets/SaveRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class SaveRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return true;
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Categories/CreateRequest.php
+++ b/src/Http/Requests/Categories/CreateRequest.php
@@ -31,6 +31,11 @@ class CreateRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Categories/DeleteRequest.php
+++ b/src/Http/Requests/Categories/DeleteRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [];

--- a/src/Http/Requests/Categories/ReorderRequest.php
+++ b/src/Http/Requests/Categories/ReorderRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class ReorderRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Categories/UpdateRequest.php
+++ b/src/Http/Requests/Categories/UpdateRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Channels/CreateRequest.php
+++ b/src/Http/Requests/Channels/CreateRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class CreateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Channel::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Channels/DeleteRequest.php
+++ b/src/Http/Requests/Channels/DeleteRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('delete', Channel::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Channels/UpdateRequest.php
+++ b/src/Http/Requests/Channels/UpdateRequest.php
@@ -7,11 +7,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules(Channel $channel)
     {
         return [

--- a/src/Http/Requests/Collections/CreateRequest.php
+++ b/src/Http/Requests/Collections/CreateRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class CreateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Collections/DeleteRequest.php
+++ b/src/Http/Requests/Collections/DeleteRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Collections/Products/UpdateRequest.php
+++ b/src/Http/Requests/Collections/Products/UpdateRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Collections/UpdateRequest.php
+++ b/src/Http/Requests/Collections/UpdateRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Currencies/DeleteRequest.php
+++ b/src/Http/Requests/Currencies/DeleteRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('delete', Currency::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Currencies/UpdateRequest.php
+++ b/src/Http/Requests/Currencies/UpdateRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('update', Currency::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules(Currency $currency)
     {
         return [

--- a/src/Http/Requests/Discounts/CreateRequest.php
+++ b/src/Http/Requests/Discounts/CreateRequest.php
@@ -31,6 +31,11 @@ class CreateRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Discounts/UpdateRequest.php
+++ b/src/Http/Requests/Discounts/UpdateRequest.php
@@ -31,6 +31,11 @@ class UpdateRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/FormRequest.php
+++ b/src/Http/Requests/FormRequest.php
@@ -29,7 +29,7 @@ abstract class FormRequest extends IlluminateFormRequest
      * Get the proper failed validation response for the request.
      *
      * @param  array  $errors
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function response(array $errors)
     {

--- a/src/Http/Requests/Languages/CreateRequest.php
+++ b/src/Http/Requests/Languages/CreateRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Core\Languages\Models\Language;
 
 class CreateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Language::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Languages/DeleteRequest.php
+++ b/src/Http/Requests/Languages/DeleteRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Core\Languages\Models\Language;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('delete', Language::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Languages/UpdateRequest.php
+++ b/src/Http/Requests/Languages/UpdateRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Core\Languages\Models\Language;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('update', Language::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules(Language $language)
     {
         return [

--- a/src/Http/Requests/Orders/Shipping/AddShippingRequest.php
+++ b/src/Http/Requests/Orders/Shipping/AddShippingRequest.php
@@ -28,6 +28,11 @@ class AddShippingRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/ProductFamilies/CreateRequest.php
+++ b/src/Http/Requests/ProductFamilies/CreateRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class CreateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Language::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/ProductFamilies/DeleteRequest.php
+++ b/src/Http/Requests/ProductFamilies/DeleteRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', Language::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/ProductFamilies/UpdateRequest.php
+++ b/src/Http/Requests/ProductFamilies/UpdateRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('create', ProductFamily::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/ProductVariants/CreateRequest.php
+++ b/src/Http/Requests/ProductVariants/CreateRequest.php
@@ -44,6 +44,11 @@ class CreateRequest extends FormRequest
         return $rules;
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/ProductVariants/DeleteRequest.php
+++ b/src/Http/Requests/ProductVariants/DeleteRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
         // return $this->user()->can('delete', Product::class);
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Products/DeleteRequest.php
+++ b/src/Http/Requests/Products/DeleteRequest.php
@@ -6,12 +6,22 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
         // return $this->user()->can('delete', Product::class);
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Products/DuplicateRequest.php
+++ b/src/Http/Requests/Products/DuplicateRequest.php
@@ -32,6 +32,11 @@ class DuplicateRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Products/UpdateAttributesRequest.php
+++ b/src/Http/Requests/Products/UpdateAttributesRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateAttributesRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [
@@ -18,6 +28,11 @@ class UpdateAttributesRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Products/UpdateCategoriesRequest.php
+++ b/src/Http/Requests/Products/UpdateCategoriesRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateCategoriesRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Products/UpdateChannelRequest.php
+++ b/src/Http/Requests/Products/UpdateChannelRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateChannelRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Products/UpdateCollectionsRequest.php
+++ b/src/Http/Requests/Products/UpdateCollectionsRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateCollectionsRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Products/UpdateCustomerGroupsRequest.php
+++ b/src/Http/Requests/Products/UpdateCustomerGroupsRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateCustomerGroupsRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Products/UpdateRequest.php
+++ b/src/Http/Requests/Products/UpdateRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         $ruleset = [
@@ -33,6 +43,11 @@ class UpdateRequest extends FormRequest
         return $ruleset;
     }
 
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/src/Http/Requests/Tags/CreateRequest.php
+++ b/src/Http/Requests/Tags/CreateRequest.php
@@ -7,11 +7,21 @@ use GetCandy\Api\Core\Tags\Models\Tag;
 
 class CreateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules(Tag $tag)
     {
         return [

--- a/src/Http/Requests/Tags/DeleteRequest.php
+++ b/src/Http/Requests/Tags/DeleteRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [];

--- a/src/Http/Requests/Tags/UpdateRequest.php
+++ b/src/Http/Requests/Tags/UpdateRequest.php
@@ -6,11 +6,21 @@ use GetCandy\Api\Http\Requests\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         $decodedId = app('api')->tags()->getDecodedId($this->tag);

--- a/src/Http/Requests/Taxes/DeleteRequest.php
+++ b/src/Http/Requests/Taxes/DeleteRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Core\Taxes\Models\Tax;
 
 class DeleteRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('delete', Tax::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
         return [

--- a/src/Http/Requests/Taxes/UpdateRequest.php
+++ b/src/Http/Requests/Taxes/UpdateRequest.php
@@ -7,12 +7,22 @@ use GetCandy\Api\Core\Taxes\Models\Tax;
 
 class UpdateRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         // return $this->user()->can('update', Tax::class);
         return $this->user()->hasRole('admin');
     }
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules(Tax $tax)
     {
         return [

--- a/src/Http/Resources/AbstractCollection.php
+++ b/src/Http/Resources/AbstractCollection.php
@@ -14,6 +14,7 @@ abstract class AbstractCollection extends ResourceCollection
      * Create a new resource instance.
      *
      * @param  mixed  $resource
+     * @param  array  $only
      * @return void
      */
     public function __construct($resource, $only = [])

--- a/src/Http/Resources/AbstractResource.php
+++ b/src/Http/Resources/AbstractResource.php
@@ -31,8 +31,8 @@ abstract class AbstractResource extends JsonResource
     /**
      * Set the singular item.
      *
-     * @param mixed $resource
-     * @return self
+     * @param  mixed  $resource
+     * @return $this
      */
     public function item($resource)
     {
@@ -44,8 +44,8 @@ abstract class AbstractResource extends JsonResource
     /**
      * Set the only fields we want to return.
      *
-     * @param array $fields
-     * @return self
+     * @param  array  $fields
+     * @return $this
      */
     public function only($fields = [])
     {
@@ -62,8 +62,8 @@ abstract class AbstractResource extends JsonResource
     /**
      * Set the channel we want to use.
      *
-     * @param string $channel
-     * @return self
+     * @param  string  $channel
+     * @return $this
      */
     public function channel($channel)
     {
@@ -75,8 +75,8 @@ abstract class AbstractResource extends JsonResource
     /**
      * Set the language to use.
      *
-     * @param string $language
-     * @return self
+     * @param  string  $language
+     * @return $this
      */
     public function language($language)
     {
@@ -89,6 +89,7 @@ abstract class AbstractResource extends JsonResource
      * Create a new resource instance.
      *
      * @param  mixed  $resource
+     * @param  array  $only
      * @return void
      */
     public function __construct($resource, $only = [])
@@ -156,8 +157,8 @@ abstract class AbstractResource extends JsonResource
     /**
      * Map the attributes.
      *
-     * @param array $data
-     * @return void
+     * @param  array  $data
+     * @return array
      */
     protected function map($data)
     {

--- a/src/Http/Transformers/Fractal/Assets/AssetTransformer.php
+++ b/src/Http/Transformers/Fractal/Assets/AssetTransformer.php
@@ -8,16 +8,28 @@ use Storage;
 
 class AssetTransformer extends BaseTransformer
 {
+    /**
+     * Include resources without needing it to be requested.
+     *
+     * @var array
+     */
     protected $defaultIncludes = [
         'tags',
     ];
+    
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'transforms',
     ];
 
     /**
-     * Decorates the attribute object for viewing.
-     * @param  Attribute $product
+     * Decorates the asset object for viewing.
+     * 
+     * @param  \GetCandy\Api\Core\Assets\Models\Asset  $asset
      * @return array
      */
     public function transform($asset)

--- a/src/Http/Transformers/Fractal/Attributes/AttributeGroupTransformer.php
+++ b/src/Http/Transformers/Fractal/Attributes/AttributeGroupTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class AttributeGroupTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'attributes',
     ];

--- a/src/Http/Transformers/Fractal/Attributes/AttributeTransformer.php
+++ b/src/Http/Transformers/Fractal/Attributes/AttributeTransformer.php
@@ -7,13 +7,19 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class AttributeTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'group',
     ];
 
     /**
      * Decorates the attribute object for viewing.
-     * @param  Attribute $product
+     * 
+     * @param  \GetCandy\Api\Core\Attributes\Models\Attribute  $product
      * @return array
      */
     public function transform(Attribute $attribute)

--- a/src/Http/Transformers/Fractal/BaseTransformer.php
+++ b/src/Http/Transformers/Fractal/BaseTransformer.php
@@ -10,7 +10,8 @@ abstract class BaseTransformer extends TransformerAbstract
 {
     /**
      * Returns the correct translation for a name array.
-     * @param  mixed $name
+     * 
+     * @param  mixed  $name
      * @return string
      */
     protected function getLocalisedName($name)

--- a/src/Http/Transformers/Fractal/Baskets/BasketLineTransformer.php
+++ b/src/Http/Transformers/Fractal/Baskets/BasketLineTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Products\ProductVariantTransformer;
 
 class BasketLineTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'variant',
     ];

--- a/src/Http/Transformers/Fractal/Baskets/BasketTransformer.php
+++ b/src/Http/Transformers/Fractal/Baskets/BasketTransformer.php
@@ -11,6 +11,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Users\UserTransformer;
 
 class BasketTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'lines', 'user', 'discounts', 'routes', 'order',
     ];

--- a/src/Http/Transformers/Fractal/Baskets/SavedBasketTransformer.php
+++ b/src/Http/Transformers/Fractal/Baskets/SavedBasketTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class SavedBasketTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     public $availableIncludes = [
         'basket',
     ];

--- a/src/Http/Transformers/Fractal/Categories/CategoryFancytreeTransformer.php
+++ b/src/Http/Transformers/Fractal/Categories/CategoryFancytreeTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class CategoryFancytreeTransformer extends BaseTransformer
 {
+    /**
+     * Include resources without needing it to be requested.
+     *
+     * @var array
+     */
     protected $defaultIncludes = [];
 
     public function transform(Category $category)

--- a/src/Http/Transformers/Fractal/Categories/CategoryTransformer.php
+++ b/src/Http/Transformers/Fractal/Categories/CategoryTransformer.php
@@ -18,6 +18,11 @@ class CategoryTransformer extends BaseTransformer
 {
     protected $attributeGroups;
 
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'attribute_groups',
         'assets',
@@ -100,8 +105,7 @@ class CategoryTransformer extends BaseTransformer
     }
 
     /**
-     * @param Category $category
-     *
+     * @param  \GetCandy\Api\Core\Categories\Models\Category  $category
      * @return \League\Fractal\Resource\Collection
      */
     public function includeChannels(Category $category)
@@ -125,8 +129,7 @@ class CategoryTransformer extends BaseTransformer
     }
 
     /**
-     * @param \GetCandy\Api\Products\Models\Product $product
-     *
+     * @param  \GetCandy\Api\Core\Categories\Models\Category  $category
      * @return \League\Fractal\Resource\Collection
      */
     public function includeAttributeGroups(Category $category)
@@ -155,8 +158,7 @@ class CategoryTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Categories\Models\Category  $category
      * @return \League\Fractal\Resource\Collection
      */
     public function includeCustomerGroups(Category $category)

--- a/src/Http/Transformers/Fractal/Channels/ChannelTransformer.php
+++ b/src/Http/Transformers/Fractal/Channels/ChannelTransformer.php
@@ -8,13 +8,19 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class ChannelTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'routes',
     ];
 
     /**
-     * Decorates the attribute object for viewing.
-     * @param  Attribute $product
+     * Decorates the channel object for viewing.
+     * 
+     * @param  \GetCandy\Api\Core\Channels\Models\Channel  $channel
      * @return array
      */
     public function transform(Channel $channel)

--- a/src/Http/Transformers/Fractal/Collections/CollectionTransformer.php
+++ b/src/Http/Transformers/Fractal/Collections/CollectionTransformer.php
@@ -17,11 +17,18 @@ class CollectionTransformer extends BaseTransformer
 {
     use IncludesAttributes;
 
+    /**
+     * Include resources without needing it to be requested.
+     *
+     * @var array
+     */
     protected $defaultIncludes = [
         'routes',
     ];
 
     /**
+     * Resources that can be included if requested.
+     *
      * @var array
      */
     protected $availableIncludes = [
@@ -33,8 +40,9 @@ class CollectionTransformer extends BaseTransformer
     ];
 
     /**
-     * Decorates the product object for viewing.
-     * @param  Collection $collection
+     * Decorates the collection object for viewing.
+     * 
+     * @param  \GetCandy\Api\Core\Collections\Models\Collection  $collection
      * @return array
      */
     public function transform(Collection $collection)
@@ -48,8 +56,10 @@ class CollectionTransformer extends BaseTransformer
 
     /**
      * Includes the products for the collection.
-     * @param  Collection $collection
-     * @return League\Fractal\Resource\Collection
+     * 
+     * @param  \GetCandy\Api\Core\Collections\Models\Collection  $collection
+     * @param  null|\League\Fractal\ParamBag  $params
+     * @return \League\Fractal\Resource\Collection
      */
     public function includeProducts(Collection $collection, ParamBag $params = null)
     {
@@ -62,8 +72,7 @@ class CollectionTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Collections\Models\Collection  $collection
      * @return \League\Fractal\Resource\Collection
      */
     public function includeChannels(Collection $collection)
@@ -74,8 +83,7 @@ class CollectionTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Collections\Models\Collection  $collection
      * @return \League\Fractal\Resource\Collection
      */
     public function includeCustomerGroups(Collection $collection)
@@ -86,8 +94,7 @@ class CollectionTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Collections\Models\Collection  $collection
      * @return \League\Fractal\Resource\Collection
      */
     public function includeRoutes(Collection $collection)

--- a/src/Http/Transformers/Fractal/Countries/CountryGroupTransformer.php
+++ b/src/Http/Transformers/Fractal/Countries/CountryGroupTransformer.php
@@ -6,6 +6,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class CountryGroupTransformer extends BaseTransformer
 {
+    /**
+     * Include resources without needing it to be requested.
+     *
+     * @var array
+     */
     protected $defaultIncludes = [
         'countries',
     ];

--- a/src/Http/Transformers/Fractal/Countries/CountryTransformer.php
+++ b/src/Http/Transformers/Fractal/Countries/CountryTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class CountryTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [];
 
     public function transform(Country $country)

--- a/src/Http/Transformers/Fractal/Currencies/CurrencyTransformer.php
+++ b/src/Http/Transformers/Fractal/Currencies/CurrencyTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class CurrencyTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [];
 
     public function transform(Currency $currency)

--- a/src/Http/Transformers/Fractal/Discounts/DiscountItemTransformer.php
+++ b/src/Http/Transformers/Fractal/Discounts/DiscountItemTransformer.php
@@ -10,6 +10,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Users\UserTransformer;
 
 class DiscountItemTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'eligibles',
     ];

--- a/src/Http/Transformers/Fractal/Discounts/DiscountRewardProductTransformer.php
+++ b/src/Http/Transformers/Fractal/Discounts/DiscountRewardProductTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Products\ProductTransformer;
 
 class DiscountRewardProductTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = ['product'];
 
     public function transform(DiscountRewardProduct $reward)

--- a/src/Http/Transformers/Fractal/Discounts/DiscountRewardTransformer.php
+++ b/src/Http/Transformers/Fractal/Discounts/DiscountRewardTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class DiscountRewardTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = ['products'];
 
     public function transform(DiscountReward $reward)

--- a/src/Http/Transformers/Fractal/Discounts/DiscountSetTransformer.php
+++ b/src/Http/Transformers/Fractal/Discounts/DiscountSetTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class DiscountSetTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'items',
     ];

--- a/src/Http/Transformers/Fractal/Discounts/DiscountTransformer.php
+++ b/src/Http/Transformers/Fractal/Discounts/DiscountTransformer.php
@@ -12,6 +12,11 @@ class DiscountTransformer extends BaseTransformer
 {
     use IncludesAttributes;
 
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'sets', 'attribute_groups', 'channels', 'rewards',
     ];
@@ -33,9 +38,8 @@ class DiscountTransformer extends BaseTransformer
     /**
      * Include the sets in the resource.
      *
-     * @param Discount $discount
-     *
-     * @return void
+     * @param  \GetCandy\Api\Core\Discounts\Models\Discount  $discount
+     * @return \League\Fractal\Resource\Collection
      */
     public function includeSets(Discount $discount)
     {
@@ -43,8 +47,7 @@ class DiscountTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Discounts\Models\Discount  $discount
      * @return \League\Fractal\Resource\Collection
      */
     public function includeChannels(Discount $discount)

--- a/src/Http/Transformers/Fractal/Languages/LanguageTransformer.php
+++ b/src/Http/Transformers/Fractal/Languages/LanguageTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class LanguageTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [];
 
     public function transform(Language $language)

--- a/src/Http/Transformers/Fractal/Layouts/LayoutTransformer.php
+++ b/src/Http/Transformers/Fractal/Layouts/LayoutTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class LayoutTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [];
 
     public function transform(Layout $layout)

--- a/src/Http/Transformers/Fractal/Orders/OrderDiscountTransformer.php
+++ b/src/Http/Transformers/Fractal/Orders/OrderDiscountTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class OrderDiscountTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'order',
     ];

--- a/src/Http/Transformers/Fractal/Orders/OrderLineTransformer.php
+++ b/src/Http/Transformers/Fractal/Orders/OrderLineTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Products\ProductVariantTransformer;
 
 class OrderLineTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = ['variant'];
 
     public function transform(OrderLine $line)

--- a/src/Http/Transformers/Fractal/Orders/OrderTransformer.php
+++ b/src/Http/Transformers/Fractal/Orders/OrderTransformer.php
@@ -10,6 +10,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Users\UserTransformer;
 
 class OrderTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'lines', 'user', 'basket', 'transactions', 'discounts', 'shipping',
     ];

--- a/src/Http/Transformers/Fractal/Pages/PageTransformer.php
+++ b/src/Http/Transformers/Fractal/Pages/PageTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class PageTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'element',
     ];

--- a/src/Http/Transformers/Fractal/Payments/TransactionTransformer.php
+++ b/src/Http/Transformers/Fractal/Payments/TransactionTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Orders\OrderTransformer;
 
 class TransactionTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'order',
     ];

--- a/src/Http/Transformers/Fractal/Plugins/PluginTransformer.php
+++ b/src/Http/Transformers/Fractal/Plugins/PluginTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class PluginTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [];
 
     public function transform(Plugin $plugin)

--- a/src/Http/Transformers/Fractal/Products/ProductAssociationTransformer.php
+++ b/src/Http/Transformers/Fractal/Products/ProductAssociationTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class ProductAssociationTransformer extends BaseTransformer
 {
+    /**
+     * Include resources without needing it to be requested.
+     *
+     * @var array
+     */
     protected $defaultIncludes = [
         'association', 'type',
     ];

--- a/src/Http/Transformers/Fractal/Products/ProductCustomerPriceTransformer.php
+++ b/src/Http/Transformers/Fractal/Products/ProductCustomerPriceTransformer.php
@@ -9,6 +9,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Taxes\TaxTransformer;
 
 class ProductCustomerPriceTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'tax', 'group',
     ];

--- a/src/Http/Transformers/Fractal/Products/ProductFamilyTransformer.php
+++ b/src/Http/Transformers/Fractal/Products/ProductFamilyTransformer.php
@@ -12,6 +12,11 @@ class ProductFamilyTransformer extends BaseTransformer
 {
     use IncludesAttributes;
 
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'products', 'attributes', 'attribute_groups',
     ];

--- a/src/Http/Transformers/Fractal/Products/ProductPricingTierTransformer.php
+++ b/src/Http/Transformers/Fractal/Products/ProductPricingTierTransformer.php
@@ -9,6 +9,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Customers\CustomerGroupTransformer;
 
 class ProductPricingTierTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'group',
     ];

--- a/src/Http/Transformers/Fractal/Products/ProductRecommendationTransformer.php
+++ b/src/Http/Transformers/Fractal/Products/ProductRecommendationTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class ProductRecommendationTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'product',
     ];

--- a/src/Http/Transformers/Fractal/Products/ProductTransformer.php
+++ b/src/Http/Transformers/Fractal/Products/ProductTransformer.php
@@ -19,6 +19,8 @@ class ProductTransformer extends BaseTransformer
     use IncludesAttributes;
 
     /**
+     * Resources that can be included if requested.
+     *
      * @var array
      */
     protected $availableIncludes = [
@@ -40,8 +42,7 @@ class ProductTransformer extends BaseTransformer
     ];
 
     /**
-     * @param \GetCandy\Api\Products\Models\Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return array
      */
     public function transform(Product $product)
@@ -88,8 +89,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param \GetCandy\Api\Products\Models\Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Item
      */
     public function includeLayout(Product $product)
@@ -102,8 +102,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param \GetCandy\Api\Products\Models\Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Item
      */
     public function includeFamily(Product $product)
@@ -116,8 +115,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param \GetCandy\Api\Products\Models\Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeCollections(Product $product)
@@ -126,8 +124,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param \GetCandy\Api\Products\Models\Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeAssociations(Product $product)
@@ -147,8 +144,8 @@ class ProductTransformer extends BaseTransformer
     /**
      * Get the resources discounts.
      *
-     * @param Product $product
-     * @return void
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
+     * @return \League\Fractal\Resource\Collection
      */
     public function includeDiscounts(Product $product)
     {
@@ -162,8 +159,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param \GetCandy\Api\Products\Models\Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeAssets(Product $product)
@@ -174,8 +170,7 @@ class ProductTransformer extends BaseTransformer
     /**
      * Includes any product variants.
      *
-     * @param  Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeVariants(Product $product)
@@ -184,8 +179,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeRoutes(Product $product)
@@ -194,8 +188,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeChannels(Product $product)
@@ -206,8 +199,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeCustomerGroups(Product $product)
@@ -218,9 +210,8 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
-     * @return \League\Fractal\Resource\Categories
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
+     * @return \League\Fractal\Resource\Collection
      */
     public function includeCategories(Product $product)
     {
@@ -228,8 +219,7 @@ class ProductTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Products\Models\Product  $product
      * @return \League\Fractal\Resource\Collection
      */
     public function includeFirstVariant(Product $product)

--- a/src/Http/Transformers/Fractal/Products/ProductVariantTransformer.php
+++ b/src/Http/Transformers/Fractal/Products/ProductVariantTransformer.php
@@ -10,6 +10,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Taxes\TaxTransformer;
 
 class ProductVariantTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'product', 'tax', 'pricing', 'tiers',
     ];

--- a/src/Http/Transformers/Fractal/Routes/ElementTransformer.php
+++ b/src/Http/Transformers/Fractal/Routes/ElementTransformer.php
@@ -8,6 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class ElementTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'element',
         'layout',

--- a/src/Http/Transformers/Fractal/Routes/RouteTransformer.php
+++ b/src/Http/Transformers/Fractal/Routes/RouteTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class RouteTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'element',
     ];

--- a/src/Http/Transformers/Fractal/Search/SearchSuggestionTransformer.php
+++ b/src/Http/Transformers/Fractal/Search/SearchSuggestionTransformer.php
@@ -8,6 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class SearchSuggestionTransformer extends BaseTransformer
 {
+    /**
+     * Include resources without needing it to be requested.
+     *
+     * @var array
+     */
     protected $defaultIncludes = ['routes', 'thumbnail'];
 
     public function transform(Model $model)

--- a/src/Http/Transformers/Fractal/Shipping/ShippingMethodTransformer.php
+++ b/src/Http/Transformers/Fractal/Shipping/ShippingMethodTransformer.php
@@ -12,6 +12,11 @@ class ShippingMethodTransformer extends BaseTransformer
 {
     use IncludesAttributes;
 
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'zones', 'prices', 'attribute_groups', 'channels', 'users', 'attributes',
     ];
@@ -41,8 +46,7 @@ class ShippingMethodTransformer extends BaseTransformer
     }
 
     /**
-     * @param ShippingMethod $method
-     *
+     * @param  \GetCandy\Api\Core\Shipping\Models\ShippingMethod  $method
      * @return \League\Fractal\Resource\Collection
      */
     public function includeChannels(ShippingMethod $method)

--- a/src/Http/Transformers/Fractal/Shipping/ShippingPriceTransformer.php
+++ b/src/Http/Transformers/Fractal/Shipping/ShippingPriceTransformer.php
@@ -10,12 +10,22 @@ use GetCandy\Api\Http\Transformers\Fractal\Customers\CustomerGroupTransformer;
 
 class ShippingPriceTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'method',
         'customer_groups',
         'zone',
     ];
 
+    /**
+     * Include resources without needing it to be requested.
+     *
+     * @var array
+     */
     protected $defaultIncludes = [
         'currency',
     ];
@@ -56,8 +66,7 @@ class ShippingPriceTransformer extends BaseTransformer
     }
 
     /**
-     * @param Product $product
-     *
+     * @param  \GetCandy\Api\Core\Shipping\Models\ShippingPrice  $price
      * @return \League\Fractal\Resource\Collection
      */
     public function includeCustomerGroups(ShippingPrice $price)

--- a/src/Http/Transformers/Fractal/Shipping/ShippingZoneTransformer.php
+++ b/src/Http/Transformers/Fractal/Shipping/ShippingZoneTransformer.php
@@ -8,6 +8,11 @@ use GetCandy\Api\Http\Transformers\Fractal\Countries\CountryTransformer;
 
 class ShippingZoneTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'countries',
     ];

--- a/src/Http/Transformers/Fractal/Tags/TagTransformer.php
+++ b/src/Http/Transformers/Fractal/Tags/TagTransformer.php
@@ -7,11 +7,17 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class TagTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [];
 
     /**
      * Decorates the tag object for viewing.
-     * @param  Tag $product
+     * 
+     * @param  \GetCandy\Api\Core\Tags\Models\Tag  $tag
      * @return array
      */
     public function transform(Tag $tag)

--- a/src/Http/Transformers/Fractal/Taxes/TaxTransformer.php
+++ b/src/Http/Transformers/Fractal/Taxes/TaxTransformer.php
@@ -7,6 +7,11 @@ use GetCandy\Api\Http\Transformers\Fractal\BaseTransformer;
 
 class TaxTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [];
 
     public function transform(Tax $tax)

--- a/src/Http/Transformers/Fractal/Users/UserTransformer.php
+++ b/src/Http/Transformers/Fractal/Users/UserTransformer.php
@@ -13,6 +13,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class UserTransformer extends BaseTransformer
 {
+    /**
+     * Resources that can be included if requested.
+     *
+     * @var array
+     */
     protected $availableIncludes = [
         'store', 'addresses', 'groups', 'roles', 'orders', 'language', 'details', 'baskets', 'reusable_payments',
     ];

--- a/src/Http/Validators/AttributeValidator.php
+++ b/src/Http/Validators/AttributeValidator.php
@@ -6,10 +6,11 @@ class AttributeValidator
 {
     /**
      * Validates the name for an attribute doesn't exist in the same group.
-     * @param  string $attribute
-     * @param  string $value
-     * @param  array $parameters
-     * @param  Validator $validator
+     * 
+     * @param  string  $attribute
+     * @param  string  $value
+     * @param  array  $parameters
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return bool
      */
     public function uniqueNameInGroup($attribute, $value, $parameters, $validator)

--- a/src/Http/Validators/BaseValidator.php
+++ b/src/Http/Validators/BaseValidator.php
@@ -6,10 +6,11 @@ class BaseValidator
 {
     /**
      * Validates the name for an attribute doesn't exist in the same group.
-     * @param  string $attribute
-     * @param  string $value
-     * @param  array $parameters
-     * @param  Validator $validator
+     * 
+     * @param  string  $attribute
+     * @param  string  $value
+     * @param  array  $parameters
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return bool
      */
     public function enabled($attribute, $value, $parameters, $validator)

--- a/src/Http/Validators/CategoriesValidator.php
+++ b/src/Http/Validators/CategoriesValidator.php
@@ -6,8 +6,11 @@ class CategoriesValidator
 {
     /**
      * Validates the name for an attribute doesn't exist in the same group.
-     * @param  string $attribute
-     * @param  string $value
+     * 
+     * @param  string  $attribute
+     * @param  string  $value
+     * @param  array  $key
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return bool
      */
     public function uniqueCategoryAttributeData($attribute, $value, $key, $validator)

--- a/src/Http/Validators/HashidValidator.php
+++ b/src/Http/Validators/HashidValidator.php
@@ -6,10 +6,11 @@ class HashidValidator
 {
     /**
      * Determines whether a given hashid correctly decodes for the given model.
-     * @param  string $attribute
-     * @param  string $value
-     * @param  array $parameters
-     * @param  Validator $validator
+     * 
+     * @param  string  $attribute
+     * @param  string  $value
+     * @param  array  $parameters
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return bool
      */
     public function validForModel($attribute, $value, $parameters, $validator)

--- a/src/Http/Validators/LocaleValidator.php
+++ b/src/Http/Validators/LocaleValidator.php
@@ -6,10 +6,11 @@ class LocaleValidator
 {
     /**
      * Validates the name for an attribute doesn't exist in the same group.
-     * @param  string $attribute
-     * @param  string $value
-     * @param  array $parameters
-     * @param  Validator $validator
+     * 
+     * @param  string  $attribute
+     * @param  string  $value
+     * @param  array  $parameters
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return bool
      */
     public function validate($attribute, $value, $parameters, $validator)

--- a/src/Http/Validators/RoutesValidator.php
+++ b/src/Http/Validators/RoutesValidator.php
@@ -6,8 +6,11 @@ class RoutesValidator
 {
     /**
      * Validates the slug for a route.
-     * @param  string $attribute
-     * @param  string $value
+     * 
+     * @param  string  $attribute
+     * @param  string  $value
+     * @param  array  $parameters
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return bool
      */
     public function uniqueRoute($attribute, $value, $parameters, $validator)

--- a/src/Installer/Events/PreflightCompletedEvent.php
+++ b/src/Installer/Events/PreflightCompletedEvent.php
@@ -4,6 +4,11 @@ namespace GetCandy\Api\Installer\Events;
 
 class PreflightCompletedEvent
 {
+    /**
+     * The response to be sent.
+     *
+     * @var array
+     */
     public $response;
 
     public function __construct($response)

--- a/src/Installer/GetCandyInstaller.php
+++ b/src/Installer/GetCandyInstaller.php
@@ -20,8 +20,18 @@ use Illuminate\Console\Command;
 
 class GetCandyInstaller
 {
+    /**
+     * The console command instance.
+     * 
+     * @var \Illuminate\Console\Command
+     */
     protected $command;
 
+    /**
+     * The runner classes that should be executed.
+     *
+     * @var array
+     */
     protected $runners = [
         'preflight' => PreflightRunner::class,
         'settings' => SettingsRunner::class,
@@ -42,8 +52,8 @@ class GetCandyInstaller
     /**
      * Sets the command instance for running the installer.
      *
-     * @param Command $command
-     * @return self
+     * @param  \Illuminate\Console\Command  $command
+     * @return $this
      */
     public function onCommand(Command $command)
     {

--- a/src/Installer/Runners/AbstractRunner.php
+++ b/src/Installer/Runners/AbstractRunner.php
@@ -10,7 +10,7 @@ abstract class AbstractRunner implements InstallRunnerContract
     /**
      * The instance of the command.
      *
-     * @var Command
+     * @var \Illuminate\Console\Command
      */
     protected $command;
 
@@ -26,8 +26,8 @@ abstract class AbstractRunner implements InstallRunnerContract
     /**
      * Sets the command instance for running the installer.
      *
-     * @param Command $command
-     * @return self
+     * @param  \Illuminate\Console\Command  $command
+     * @return $this
      */
     public function onCommand(Command $command)
     {

--- a/src/Installer/Runners/AttributeRunner.php
+++ b/src/Installer/Runners/AttributeRunner.php
@@ -65,7 +65,7 @@ class AttributeRunner extends AbstractRunner implements InstallRunnerContract
     /**
      * Add the SEO attributes.
      *
-     * @param int $groupId
+     * @param  int  $groupId
      * @return void
      */
     protected function addSeoAttributes($groupId)
@@ -78,7 +78,7 @@ class AttributeRunner extends AbstractRunner implements InstallRunnerContract
     /**
      * Add the marketing attributes.
      *
-     * @param int $groupId
+     * @param  int  $groupId
      * @return void
      */
     protected function addMarketingAttributes($groupId)
@@ -91,7 +91,7 @@ class AttributeRunner extends AbstractRunner implements InstallRunnerContract
     /**
      * Get the marketing attributes.
      *
-     * @param int $groupId
+     * @param  int  $groupId
      * @return array
      */
     public function getMarketingAttributes($groupId)
@@ -139,7 +139,7 @@ class AttributeRunner extends AbstractRunner implements InstallRunnerContract
     /**
      * Get the SEO attributes to be installed.
      *
-     * @param int $groupId
+     * @param  int  $groupId
      * @return array
      */
     public function getSeoAttributes($groupId)

--- a/src/Installer/Runners/LanguageRunner.php
+++ b/src/Installer/Runners/LanguageRunner.php
@@ -7,6 +7,9 @@ use GetCandy\Api\Installer\Contracts\InstallRunnerContract;
 
 class LanguageRunner extends AbstractRunner implements InstallRunnerContract
 {
+    /**
+     * @var \Illuminate\Support\Collection
+     */
     protected $availableLanguages;
 
     public function __construct()

--- a/src/Installer/Runners/UserRunner.php
+++ b/src/Installer/Runners/UserRunner.php
@@ -28,8 +28,8 @@ class UserRunner extends AbstractRunner implements InstallRunnerContract
     /**
      * Set up the user based on a model reference.
      *
-     * @param string $model
-     * @return Illuminate\Database\Eloquent\Model
+     * @param  string  $model
+     * @return \Illuminate\Database\Eloquent\Model
      */
     protected function setUpUser($model)
     {

--- a/src/Jobs/SyncAttributeDataJob.php
+++ b/src/Jobs/SyncAttributeDataJob.php
@@ -12,16 +12,23 @@ class SyncAttributeDataJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * An array of attributes hashed ids.
+     *
+     * @var array
+     */
     protected $ids;
 
+    /**
+     * @var string|null
+     */
     protected $type;
 
     /**
      * Create a new job instance.
      *
-     * @param array $ids
-     * @param string $type
-     *
+     * @param  array  $ids
+     * @param  string|null  $type
      * @return void
      */
     public function __construct(array $ids, $type = null)

--- a/src/Jobs/Utils/ImportJob.php
+++ b/src/Jobs/Utils/ImportJob.php
@@ -15,14 +15,15 @@ class ImportJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * @var \GetCandy\Api\Core\Utils\Import\Models\Import
+     */
     protected $import;
 
     /**
      * Create a new job instance.
      *
-     * @param array $ids
-     * @param string $type
-     *
+     * @param  \GetCandy\Api\Core\Utils\Import\Models\Import  $import
      * @return void
      */
     public function __construct(Import $import)
@@ -33,6 +34,7 @@ class ImportJob implements ShouldQueue
     /**
      * Execute the job.
      *
+     * @param  \GetCandy\Api\Core\Utils\Import\ImportManagerContract $importer
      * @return void
      */
     public function handle(ImportManagerContract $importer)


### PR DESCRIPTION
This PR is intended to correct, and in some cases add or remove DocBlocks on structural elements (classes, properties, methods) throughout the codebase. No plans to deal or change the actual functional code.

While this might seem sort of unnecessary at this time, I think it's important to have well-documented code that follows the PHPDoc standards, a good step toward to (maybe) facilitate the implementation of strict type in the future, when PHP's type-hinting system gets mature enough and JIT compiler lands to PHP so we could benefit from better performance, cleaner and self-explanatory code.

The goal isn't to bloat the code with unnecessary DocBlocks where it might be self-explanatory enough, so this PR is taking the following considerations:
- All changes will try to stick to the (proposed) [PSR-5 for PHPDoc](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md).
- When adding or removing DocBlocks two rules will be followed:
    - Add a DocBlock when it adds value.
    - Remove a DocBlock when it does not add value, that means that they only repeat information that is already present on the structural elements they intend to document.
- Fully Qualified Class Names (FQCN) will be used in the DocBlocks so
    - It is consistent with the Laravel way of doing things.
    - You know exactly which namespace the class belongs to, no need to scroll all the way up to see an import.
    - It will be easier in the future to update them all at once.
    - They could facilitate the transition to a strict type codebase.