### PR TITLE
Removed unused class

### DIFF
--- a/src/Core/Users/Services/UserService.php
+++ b/src/Core/Users/Services/UserService.php
@@ -2,7 +2,6 @@
 
 namespace GetCandy\Api\Core\Users\Services;
 
-use GetCandy\Api\Core\Auth\Models\User;
 use GetCandy\Api\Core\Payments\Models\ReusablePayment;
 use GetCandy\Api\Core\Scaffold\BaseService;
 use GetCandy\Api\Core\Users\Contracts\UserContract;


### PR DESCRIPTION
Removed import `GetCandy\Api\Core\Auth\Models\User` from `UserService.php` as it is no longer being used, but rather the model specified in `auth.php` config file.