### PR TITLE
Fixed exception classes with incorrect namespace

### DIFF
--- a/src/Core/Attributes/Services/AttributeGroupService.php
+++ b/src/Core/Attributes/Services/AttributeGroupService.php
@@ -4,7 +4,7 @@ namespace GetCandy\Api\Core\Attributes\Services;
 
 use GetCandy\Api\Core\Attributes\Models\AttributeGroup;
 use GetCandy\Api\Core\Scaffold\BaseService;
-use GetCandy\Exceptions\DuplicateValueException;
+use GetCandy\Api\Exceptions\DuplicateValueException;
 
 class AttributeGroupService extends BaseService
 {

--- a/src/Core/Attributes/Services/AttributeService.php
+++ b/src/Core/Attributes/Services/AttributeService.php
@@ -5,7 +5,7 @@ namespace GetCandy\Api\Core\Attributes\Services;
 use GetCandy\Api\Core\Attributes\Events\AttributeSavedEvent;
 use GetCandy\Api\Core\Attributes\Models\Attribute;
 use GetCandy\Api\Core\Scaffold\BaseService;
-use GetCandy\Exceptions\DuplicateValueException;
+use GetCandy\Api\Exceptions\DuplicateValueException;
 
 class AttributeService extends BaseService
 {

--- a/src/Core/Factory.php
+++ b/src/Core/Factory.php
@@ -325,7 +325,7 @@ class Factory
     public function __call($name, $arguments)
     {
         if (! property_exists($this, $name)) {
-            throw new \GetCandy\Exceptions\InvalidServiceException(trans('exceptions.invalid_service', [
+            throw new \GetCandy\Api\Exceptions\InvalidServiceException(trans('exceptions.invalid_service', [
                 'service' => $name,
             ]), 1);
         }

--- a/src/Core/Pages/Services/PageService.php
+++ b/src/Core/Pages/Services/PageService.php
@@ -4,7 +4,7 @@ namespace GetCandy\Api\Core\Pages\Services;
 
 use GetCandy\Api\Core\Pages\Models\Page;
 use GetCandy\Api\Core\Scaffold\BaseService;
-use GetCandy\Exceptions\InvalidLanguageException;
+use GetCandy\Api\Exceptions\InvalidLanguageException;
 use Illuminate\Database\Eloquent\Model;
 
 class PageService extends BaseService

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GetCandy\Events;
+namespace GetCandy\Api\Events;
 
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;

--- a/src/Exceptions/Api/Assets/InvalidAssetSourceException.php
+++ b/src/Exceptions/Api/Assets/InvalidAssetSourceException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GetCandy\Exceptions\Api\Assets;
+namespace GetCandy\Api\Exceptions\Api\Assets;
 
 use Exception;
 

--- a/src/Exceptions/DuplicateValueException.php
+++ b/src/Exceptions/DuplicateValueException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GetCandy\Exceptions;
+namespace GetCandy\Api\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -3,7 +3,7 @@
 namespace GetCandy\Api\Exceptions;
 
 use Exception;
-use GetCandy\Api\Traits\Fractal;
+use GetCandy\Api\Core\Traits\Fractal;
 use GetCandy\Api\Exceptions\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -4,7 +4,7 @@ namespace GetCandy\Api\Exceptions;
 
 use Exception;
 use GetCandy\Api\Traits\Fractal;
-use GetCandy\Exceptions\Api\AuthorizationException;
+use GetCandy\Api\Exceptions\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/src/Exceptions/InvalidLanguageException.php
+++ b/src/Exceptions/InvalidLanguageException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GetCandy\Exceptions;
+namespace GetCandy\Api\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/InvalidServiceException.php
+++ b/src/Exceptions/InvalidServiceException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GetCandy\Exceptions;
+namespace GetCandy\Api\Exceptions;
 
 use Exception;
 

--- a/src/Http/Controllers/Attributes/AttributeGroupController.php
+++ b/src/Http/Controllers/Attributes/AttributeGroupController.php
@@ -11,7 +11,7 @@ use GetCandy\Api\Http\Resources\Attributes\AttributeGroupCollection;
 use GetCandy\Api\Http\Resources\Attributes\AttributeGroupResource;
 use GetCandy\Api\Http\Transformers\Fractal\Attributes\AttributeGroupTransformer;
 use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
-use GetCandy\Exceptions\DuplicateValueException;
+use GetCandy\Api\Exceptions\DuplicateValueException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/src/Http/Controllers/Products/ProductController.php
+++ b/src/Http/Controllers/Products/ProductController.php
@@ -17,7 +17,7 @@ use GetCandy\Api\Http\Resources\Products\ProductCollection;
 use GetCandy\Api\Http\Resources\Products\ProductRecommendationCollection;
 use GetCandy\Api\Http\Resources\Products\ProductResource;
 use GetCandy\Api\Http\Transformers\Fractal\Products\ProductTransformer;
-use GetCandy\Exceptions\InvalidLanguageException;
+use GetCandy\Api\Exceptions\InvalidLanguageException;
 use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Hashids;
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/src/Http/Controllers/Products/ProductFamilyController.php
+++ b/src/Http/Controllers/Products/ProductFamilyController.php
@@ -10,7 +10,7 @@ use GetCandy\Api\Http\Requests\ProductFamilies\UpdateRequest;
 use GetCandy\Api\Http\Resources\Products\ProductFamilyCollection;
 use GetCandy\Api\Http\Resources\Products\ProductFamilyResource;
 use GetCandy\Api\Http\Transformers\Fractal\Products\ProductFamilyTransformer;
-use GetCandy\Exceptions\InvalidLanguageException;
+use GetCandy\Api\Exceptions\InvalidLanguageException;
 use GetCandy\Api\Exceptions\MinimumRecordRequiredException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;

--- a/src/Http/Controllers/Products/ProductVariantController.php
+++ b/src/Http/Controllers/Products/ProductVariantController.php
@@ -9,7 +9,7 @@ use GetCandy\Api\Http\Requests\ProductVariants\UpdateRequest;
 use GetCandy\Api\Http\Resources\Products\ProductResource;
 use GetCandy\Api\Http\Resources\Products\ProductVariantCollection;
 use GetCandy\Api\Http\Resources\Products\ProductVariantResource;
-use GetCandy\Exceptions\InvalidLanguageException;
+use GetCandy\Api\Exceptions\InvalidLanguageException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;


### PR DESCRIPTION
There were exceptions classes that had an incorrect namespace, all of them were corrected with this PR.