### PR TITLE
Paranthesize nested ternary operators

### DIFF
--- a/src/Http/Controllers/Search/SearchController.php
+++ b/src/Http/Controllers/Search/SearchController.php
@@ -39,7 +39,7 @@ class SearchController extends BaseController
     {
         // Get channel
         $defaultChannel = $this->channels->getDefaultRecord();
-        $channel = $request->channel ?: $defaultChannel ? $defaultChannel->handle : null;
+        $channel = $request->channel ?: ($defaultChannel ? $defaultChannel->handle : null);
 
         try {
             $categories = $this->categories->getByHashedIds(


### PR DESCRIPTION
This is a fix for issue #219 

Issue describes the use of unparenthesized nested ternary operators which will result in an Error Exception in PHP 7.4 as this is [deprecated](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary).