### PR TITLE
Added Guzzle as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ public/images/vendor/jquery.fancytree/dist/skin-win8/vline-rtl.gif
 /.vscode
 composer.lock
 PHPCompatibility/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "laravel/helpers": "1.2.0",
         "neondigital/laravel-drafting": "dev-master",
         "neondigital/laravel-versioning": "dev-master",
-        "staudenmeir/eloquent-has-many-deep": "^1.7"
+        "staudenmeir/eloquent-has-many-deep": "^1.7",
+        "guzzlehttp/guzzle": "^6.5"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",


### PR DESCRIPTION
This PR adds `guzzlehttp/guzzle` to the `composer.json` as a dependency to make the test  `SagePayTest` pass, as it currently failing due to it is missing the Guzzle Client, see the PHPUnit output below.

Additionally, it's been added `.phpunit.result.cache` to the `.gitignore` file, as this file is being generated every time the tests are run.

### PHPUnit output
```
PHPUnit 8.5.5 by Sebastian Bergmann and contributors.

................................................................. 65 / 84 ( 77%)
.....E

Time: 34.64 seconds, Memory: 118.00 MB

There was 1 error:

1) Tests\Unit\Payments\Providers\SagePayTest::test_can_be_instantiated
ReflectionException: Class GuzzleHttp\Client does not exist
```