### PR TITLE
Feat/search performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ public/images/vendor/jquery.fancytree/dist/skin-win8/vline-rtl.gif
 /.vscode
 composer.lock
 PHPCompatibility/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "laravel/helpers": "1.2.0",
         "neondigital/laravel-drafting": "dev-master",
         "neondigital/laravel-versioning": "dev-master",
-        "staudenmeir/eloquent-has-many-deep": "^1.7"
+        "staudenmeir/eloquent-has-many-deep": "^1.7",
+        "guzzlehttp/guzzle": "^6.5"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/config/getcandy.php
+++ b/config/getcandy.php
@@ -132,6 +132,7 @@ return [
     */
     'search' => [
         'client' => \GetCandy\Api\Core\Search\Providers\Elastic\Elastic::class,
+        'batch_size' => 1000,
         'client_config' => [
             'elastic' => [
                 'host' => null,

--- a/database/migrations/2017_08_04_084909_create_assets_table.php
+++ b/database/migrations/2017_08_04_084909_create_assets_table.php
@@ -43,6 +43,8 @@ class CreateAssetsTable extends Migration
      */
     public function down()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::dropIfExists('assets');
+        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2020_01_09_122840_remove_unique_sku_constraint.php
+++ b/database/migrations/2020_01_09_122840_remove_unique_sku_constraint.php
@@ -27,7 +27,8 @@ class RemoveUniqueSkuConstraint extends Migration
     public function down()
     {
         Schema::table('product_variants', function (Blueprint $table) {
-            $table->addUnique(['sku']);
+            $table->dropIndex(['sku']);
+            $table->unique(['sku']);
         });
     }
 }

--- a/database/migrations/2020_01_24_142705_migrate_assets_to_link_table.php
+++ b/database/migrations/2020_01_24_142705_migrate_assets_to_link_table.php
@@ -55,5 +55,19 @@ class MigrateAssetsToLinkTable extends Migration
 
     public function down()
     {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->integer('position')->after('asset_source_id');
+        });
+        Schema::table('assets', function (Blueprint $table) {
+            $table->string('assetable_type')->after('location');
+        });
+        Schema::table('assets', function (Blueprint $table) {
+            $table->bigInteger('assetable_id')->after('assetable_type');
+        });
+        Schema::table('assets', function (Blueprint $table) {
+            $table->boolean('primary')->after('assetable_id')->default(false);
+        });
+
+        Schema::dropIfExists('assetables');
     }
 }

--- a/database/migrations/2020_06_16_095615_add_missing_indexes_to_tables.php
+++ b/database/migrations/2020_06_16_095615_add_missing_indexes_to_tables.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMissingIndexesToTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('channel_product', function (Blueprint $table) {
+            $table->index('published_at');
+        });
+        Schema::table('category_channel', function (Blueprint $table) {
+            $table->index('published_at');
+        });
+        Schema::table('channel_collection', function (Blueprint $table) {
+            $table->index('published_at');
+        });
+        Schema::table('channel_discount', function (Blueprint $table) {
+            $table->index('published_at');
+        });
+        Schema::table('customer_group_product', function (Blueprint $table) {
+            $table->index('visible');
+            $table->index('purchasable');
+        });
+    }
+
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2020_11_03_2020_add_indexes_to_orders.php
+++ b/database/migrations/2020_11_03_2020_add_indexes_to_orders.php
@@ -34,7 +34,7 @@ class AddIndexesToOrders extends Migration
     public function down()
     {
         Schema::table('orders', function (Blueprint $table) {
-            $table->dropIndex(['placed_at']);
+            // $table->dropIndex(['placed_at']);
             $table->dropIndex(['sub_total']);
             $table->dropIndex(['shipping_method']);
             $table->dropIndex(['shipping_preference']);

--- a/src/Console/Commands/CandySearchIndexCommand.php
+++ b/src/Console/Commands/CandySearchIndexCommand.php
@@ -59,7 +59,7 @@ class CandySearchIndexCommand extends Command
             if ($this->option('queue')) {
                 ReindexSearchJob::dispatch($indexable);
             } else {
-                $search->indexer()->reindex($model, config('getcandy.search.batch_size'));
+                $search->indexer()->reindex($model, config('getcandy.search.batch_size', 1000));
             }
         }
 

--- a/src/Console/Commands/CandySearchIndexCommand.php
+++ b/src/Console/Commands/CandySearchIndexCommand.php
@@ -59,7 +59,7 @@ class CandySearchIndexCommand extends Command
             if ($this->option('queue')) {
                 ReindexSearchJob::dispatch($indexable);
             } else {
-                $search->indexer()->reindex($model);
+                $search->indexer()->reindex($model, config('getcandy.search.batch_size'));
             }
         }
 

--- a/src/Core/Categories/Services/CategoryService.php
+++ b/src/Core/Categories/Services/CategoryService.php
@@ -316,7 +316,7 @@ class CategoryService extends BaseService
         return $category->delete();
     }
 
-    public function getSearchedIds($ids = [])
+    public function getSearchedIds($ids = [], $includes = [])
     {
         $parsedIds = [];
         foreach ($ids as $hash) {
@@ -325,14 +325,7 @@ class CategoryService extends BaseService
 
         $placeholders = implode(',', array_fill(0, count($parsedIds), '?')); // string for the query
 
-        $query = $this->model->with([
-            'routes',
-            'products',
-            'assets',
-            'primaryAsset.transforms',
-            'primaryAsset.source',
-            'primaryAsset',
-        ])
+        $query = $this->model->with($includes)
             ->withoutGlobalScopes()
             ->whereIn('id', $parsedIds);
 

--- a/src/Core/Products/ProductCriteria.php
+++ b/src/Core/Products/ProductCriteria.php
@@ -22,13 +22,12 @@ class ProductCriteria extends AbstractCriteria
     public function getBuilder()
     {
         $product = new Product;
-        $builder = $product->channel($this->channel)->with($this->includes ?: []);
+        $builder = $product->with($this->includes ?: []);
         if ($this->sku) {
             $builder->whereHas('variants', function ($q) {
                 $q->where('sku', '=', $this->sku);
             });
         }
-
         if (count($this->ids)) {
             return $builder->whereIn('id', $product->decodeIds($this->ids));
         }

--- a/src/Core/Products/Services/ProductService.php
+++ b/src/Core/Products/Services/ProductService.php
@@ -341,7 +341,7 @@ class ProductService extends BaseService
         return $attributes;
     }
 
-    public function getSearchedIds($ids = [], $user = null)
+    public function getSearchedIds($ids = [], Array $includes = [])
     {
         $parsedIds = [];
         foreach ($ids as $hash) {
@@ -355,27 +355,13 @@ class ProductService extends BaseService
 
         $placeholders = implode(',', array_fill(0, count($parsedIds), '?')); // string for the query
 
-        $query = $this->model->with([
-            'routes',
-            'firstVariant',
-            'assets.transforms',
-            'variants.product',
-            'variants.tiers',
-            'variants.tiers.group',
-            'variants.customerPricing',
-            'primaryAsset',
-            'primaryAsset.transforms.transform',
-            'primaryAsset.transforms.asset',
-            'primaryAsset.transforms.asset.source',
-            'primaryAsset.tags',
-            'primaryAsset.source',
-        ])->whereIn('id', $parsedIds);
+        $query = $this->model->with($includes)->whereIn('products.id', $parsedIds);
 
         if (count($parsedIds)) {
-            $query = $query->orderByRaw("field(id,{$placeholders})", $parsedIds);
+            $query = $query->orderByRaw("field(products.id,{$placeholders})", $parsedIds);
         }
 
-        return $this->factory->collection($query->get());
+        return $query->get();
     }
 
     /**

--- a/src/Core/Scopes/ChannelScope.php
+++ b/src/Core/Scopes/ChannelScope.php
@@ -20,10 +20,14 @@ class ChannelScope extends AbstractScope
     {
         $channel = app()->getInstance()->make(ChannelFactoryInterface::class);
         $this->resolve(function () use ($builder, $channel) {
-            $builder->whereHas('channels', function ($query) use ($channel) {
-                $query->whereHandle($channel->current())
-                    ->whereDate('published_at', '<=', Carbon::now());
-            });
+            $model = $builder->getModel();
+            $relation = $model->channels();
+            $builder->join($relation->getTable(), function ($join) use ($relation, $model, $channel) {
+                $join->on("{$model->getTable()}.id", '=', $relation->getExistenceCompareKey())
+                ->where("{$relation->getTable()}.channel_id", $channel->getChannel()->id)
+                ->where("{$relation->getTable()}.published_at", '<=', Carbon::now())
+                ;
+            })->groupBy($relation->getExistenceCompareKey());
         });
     }
 

--- a/src/Core/Scopes/CustomerGroupScope.php
+++ b/src/Core/Scopes/CustomerGroupScope.php
@@ -17,8 +17,13 @@ class CustomerGroupScope extends AbstractScope
     public function apply(Builder $builder, Model $model)
     {
         $this->resolve(function () use ($builder) {
-            $builder->whereHas('customerGroups', function ($q) {
-                $q->whereIn('customer_groups.id', $this->getGroups())->where('visible', '=', true);
+            $model = $builder->getModel();
+            $relation = $model->customerGroups();
+            $builder->join($relation->getTable(), function ($join) use ($relation, $model) {
+                $join->on("{$model->getTable()}.id", '=', $relation->getExistenceCompareKey())
+                ->whereIn("{$relation->getTable()}.customer_group_id", $this->getGroups())
+                ->where("{$relation->getTable()}.visible", '=', true)
+                ->groupBy($relation->getExistenceCompareKey());
             });
         });
     }

--- a/src/Core/Search/Providers/Elastic/AggregationResolver.php
+++ b/src/Core/Search/Providers/Elastic/AggregationResolver.php
@@ -109,9 +109,4 @@ class AggregationResolver
             return ! empty($agg['data']) ? $agg['data']->resource->position : 0;
         });
     }
-
-    protected function resolveCategories()
-    {
-
-    }
 }

--- a/src/Core/Search/Providers/Elastic/AggregationResolver.php
+++ b/src/Core/Search/Providers/Elastic/AggregationResolver.php
@@ -55,8 +55,8 @@ class AggregationResolver
             return Str::contains($key, '_after');
         });
         return [
-            'pre' => $this->resolveAggregations($preAggs),
-            'post' => $this->resolveAggregations($postAggs),
+            'available' => $this->resolveAggregations($preAggs),
+            'applied' => $this->resolveAggregations($postAggs),
         ];
     }
 

--- a/src/Core/Search/Providers/Elastic/AggregationResolver.php
+++ b/src/Core/Search/Providers/Elastic/AggregationResolver.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace GetCandy\Api\Core\Search\Providers\Elastic;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use GetCandy\Api\Http\Resources\Categories\CategoryResource;
+use GetCandy\Api\Http\Resources\Attributes\AttributeResource;
+
+class AggregationResolver
+{
+
+    /**
+     * Returns the attributes which have been aggregated
+     *
+     * @param   array  $handles  Array of attribute handles
+     *
+     * @return  \Illuminate\Support\Collection
+     */
+    public function getAggregatedAttributes(array $handles)
+    {
+        return app('api')->attributes()->getByHandles($handles);
+    }
+
+    /**
+     * Returns categories which have been aggregated
+     *
+     * @param   array  $buckets  The category aggregate bucket data
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAggregatedCategories(array $buckets)
+    {
+        return app('api')->categories()->getByHashedIds(
+            collect($buckets)->map(function ($cat) {
+                return $cat['key'];
+            })->toArray()
+        );
+    }
+
+    /**
+     * Resolve the search aggregations
+     *
+     * @param   array  $aggregations
+     *
+     * @return  array                the resolved aggregations
+     */
+    public function resolve(array $aggregations)
+    {
+        $preAggs = collect($aggregations)->filter(function ($agg, $key) {
+            return !Str::contains($key, '_after');
+        });
+        $postAggs = collect($aggregations)->filter(function ($agg, $key) {
+            return Str::contains($key, '_after');
+        });
+        return [
+            'pre' => $this->resolveAggregations($preAggs),
+            'post' => $this->resolveAggregations($postAggs),
+        ];
+    }
+
+    protected function resolveAggregations(Collection $aggregations)
+    {
+        // Get our attributes here so they're only fetched once
+        $attributes = $this->getAggregatedAttributes(
+            $aggregations->mapWithKeys(function ($agg, $key) {
+                return [str_replace('_after', '', $key) => null];
+            })->keys()->all()
+        );
+
+        $categories = collect();
+
+        if ($categoryBuckets = Arr::get($aggregations, 'categories.categories.buckets')) {
+            // Get the categories here so they're only fetched once
+            $categories = $this->getAggregatedCategories($categoryBuckets);
+        }
+
+        return $aggregations->mapWithKeys(function ($agg, $key) use ($attributes, $categories) {
+            $key = str_replace('_after', '', $key);
+
+            $extra = [
+                'handle' => $key,
+            ];
+
+            $data = $agg[$key] ?? $agg;
+
+            if ($key == 'categories') {
+                foreach ($data['buckets'] as $bucketIndex => $bucket) {
+                    $category = $categories->first(function ($cat) use ($bucket) {
+                        return $cat->encodedId() == $bucket['key'];
+                    });
+
+                    if ($category) {
+                        $data['buckets'][$bucketIndex]['data'] = new CategoryResource($category);
+                    } else {
+                        unset($data['buckets'][$bucketIndex]);
+                    }
+                }
+            } else {
+                $attribute = $attributes->first(function ($att) use ($key) {
+                    return $att->handle == $key;
+                });
+                $extra['data'] = new AttributeResource($attribute);
+            }
+
+            return [$key =>  array_merge($extra, $data)];
+        })->sortBy(function ($agg) {
+            return ! empty($agg['data']) ? $agg['data']->resource->position : 0;
+        });
+    }
+
+    protected function resolveCategories()
+    {
+
+    }
+}

--- a/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
+++ b/src/Core/Search/Providers/Elastic/Aggregators/Attribute.php
@@ -109,8 +109,10 @@ class Attribute
             $value = [$value];
         }
 
+
+        $postBool = new BoolQuery();
+
         foreach ($value as $value) {
-            $postBool = new BoolQuery();
             $match = new Match;
             $match->setFieldAnalyzer($this->field, 'standard');
             $match->setFieldQuery($this->field, $value);

--- a/src/Core/Search/Providers/Elastic/Elastic.php
+++ b/src/Core/Search/Providers/Elastic/Elastic.php
@@ -2,11 +2,9 @@
 
 namespace GetCandy\Api\Core\Search\Providers\Elastic;
 
-use GetCandy\Api\Core\Search\Providers\Elastic\Types\ProductType;
 use GetCandy\Api\Core\Search\SearchContract;
-use GetCandy\Api\Http\Resources\Attributes\AttributeResource;
-use GetCandy\Api\Http\Resources\Categories\CategoryResource;
-use Illuminate\Support\Arr;
+use GetCandy\Api\Core\Search\Providers\Elastic\Types\ProductType;
+use GetCandy\Api\Core\Search\Providers\Elastic\AggregationResolver;
 
 class Elastic implements SearchContract
 {
@@ -43,44 +41,8 @@ class Elastic implements SearchContract
 
     public function parseAggregations(array $aggregations)
     {
-        // Get our attributes.
-        $attributes = app('api')->attributes()->getByHandles(array_keys($aggregations));
-
-        $categoryBuckets = Arr::get($aggregations, 'categories.categories.buckets');
-
-        $categoryIds = collect($categoryBuckets)->map(function ($cat) {
-            return $cat['key'];
-        });
-
-        $categories = app('api')->categories()->getByHashedIds($categoryIds->toArray());
-
-        return collect($aggregations)->map(function ($agg, $key) use ($attributes, $categories) {
-            $extra = [
-                'handle' => $key,
-            ];
-
-            if ($key == 'categories') {
-                foreach ($agg['categories']['buckets'] as $bucketIndex => $bucket) {
-                    $category = $categories->first(function ($cat) use ($bucket) {
-                        return $cat->encodedId() == $bucket['key'];
-                    });
-
-                    if ($category) {
-                        $agg['categories']['buckets'][$bucketIndex]['data'] = new CategoryResource($category);
-                    } else {
-                        unset($agg['categories']['buckets'][$bucketIndex]);
-                    }
-                }
-            } else {
-                $attribute = $attributes->first(function ($att) use ($key) {
-                    return $att->handle == $key;
-                });
-                $extra['data'] = new AttributeResource($attribute);
-            }
-
-            return array_merge($extra, $agg[$key]);
-        })->sortBy(function ($agg) {
-            return ! empty($agg['data']) ? $agg['data']->resource->position : 0;
-        });
+        return (new AggregationResolver)->resolve(
+            $aggregations
+        );
     }
 }

--- a/src/Core/Search/Providers/Elastic/Elastic.php
+++ b/src/Core/Search/Providers/Elastic/Elastic.php
@@ -2,8 +2,11 @@
 
 namespace GetCandy\Api\Core\Search\Providers\Elastic;
 
-use GetCandy\Api\Core\Search\Providers\Elastic\Types\ProductType;
+use Illuminate\Support\Arr;
 use GetCandy\Api\Core\Search\SearchContract;
+use GetCandy\Api\Http\Resources\Categories\CategoryResource;
+use GetCandy\Api\Http\Resources\Attributes\AttributeResource;
+use GetCandy\Api\Core\Search\Providers\Elastic\Types\ProductType;
 
 class Elastic implements SearchContract
 {
@@ -36,5 +39,49 @@ class Elastic implements SearchContract
     public function products()
     {
         return app()->make(ProductType::class);
+    }
+
+
+    public function parseAggregations(array $aggregations)
+    {
+        // Get our attributes.
+        $attributes = app('api')->attributes()->getByHandles(array_keys($aggregations));
+
+        $categoryBuckets = Arr::get($aggregations, 'categories.categories.buckets');
+
+        $categoryIds = collect($categoryBuckets)->map(function ($cat) {
+            return $cat['key'];
+        });
+
+        $categories = app('api')->categories()->getByHashedIds($categoryIds->toArray());
+
+        return collect($aggregations)->map(function ($agg, $key) use ($attributes, $categories) {
+            $extra = [
+                'handle' => $key
+            ];
+
+            if ($key == 'categories') {
+                foreach ($agg['categories']['buckets'] as $bucketIndex => $bucket) {
+
+                    $category = $categories->first(function ($cat) use ($bucket) {
+                        return $cat->encodedId() == $bucket['key'];
+                    });
+
+                    if ($category) {
+                        $agg['categories']['buckets'][$bucketIndex]['data'] = new CategoryResource($category);
+                    } else {
+                        unset($agg['categories']['buckets'][$bucketIndex]);
+                    }
+                }
+            } else {
+                $attribute = $attributes->first(function ($att) use ($key) {
+                    return $att->handle == $key;
+                });
+                $extra['data'] = new AttributeResource($attribute);
+            }
+            return array_merge($extra, $agg[$key]);
+        })->sortBy(function ($agg) {
+            return !empty($agg['data']) ? $agg['data']->resource->position : 0;
+        });
     }
 }

--- a/src/Core/Search/Providers/Elastic/Indexer.php
+++ b/src/Core/Search/Providers/Elastic/Indexer.php
@@ -48,7 +48,7 @@ class Indexer
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function reindex($model)
+    public function reindex($model, $batchSize = 1000)
     {
         $type = $this->resolver->getType($model);
 
@@ -74,7 +74,7 @@ class Indexer
         $models = $model->withoutGlobalScopes([
             CustomerGroupScope::class,
             ChannelScope::class,
-        ])->limit(1000)
+        ])->limit($batchSize)
             ->offset($this->batch)
             ->get();
 
@@ -108,11 +108,11 @@ class Indexer
             $elasticaType->getIndex()->refresh();
 
             echo ':batch:'.$this->batch;
-            $this->batch += 1000;
+            $this->batch += $batchSize;
             $models = $model->withoutGlobalScopes([
                 CustomerGroupScope::class,
                 ChannelScope::class,
-            ])->limit(1000)->offset($this->batch)->get();
+            ])->limit($batchSize)->offset($this->batch)->get();
         }
 
         foreach ($aliases as $alias => $index) {

--- a/src/Core/Search/Providers/Elastic/SearchBuilder.php
+++ b/src/Core/Search/Providers/Elastic/SearchBuilder.php
@@ -515,7 +515,14 @@ class SearchBuilder
             return ! in_array($filter['handle'], $this->topFilters);
         });
 
-        $postFilters->each(function ($filter) use ($postFilter) {
+        $postFilters->each(function ($filter) use ($postFilter, $query) {
+            if (method_exists($filter['filter'], 'aggregate')) {
+                $query->addAggregation(
+                    $filter['filter']->aggregate()->getPost(
+                        $filter['filter']->getValue()
+                    )
+                );
+            }
             $postFilter->addFilter(
                 $filter['filter']->getQuery()
             );

--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -35,6 +35,10 @@ class BaseController extends Controller
             $includes = explode(',', $includes);
         }
 
-        return $includes;
+        return array_map(function ($x) {
+            return lcfirst(implode(array_map(function ($y) {
+                return ucfirst($y);
+            }, explode('_', $x))));
+        }, $includes);
     }
 }

--- a/src/Http/Controllers/Search/SearchController.php
+++ b/src/Http/Controllers/Search/SearchController.php
@@ -2,15 +2,19 @@
 
 namespace GetCandy\Api\Http\Controllers\Search;
 
-use GetCandy\Api\Core\Categories\Services\CategoryService;
-use GetCandy\Api\Core\Channels\Services\ChannelService;
-use GetCandy\Api\Core\Products\Models\Product;
+use Illuminate\Http\Request;
 use GetCandy\Api\Core\Search\SearchContract;
+use GetCandy\Api\Core\Products\Models\Product;
+use Illuminate\Pagination\LengthAwarePaginator;
 use GetCandy\Api\Http\Controllers\BaseController;
 use GetCandy\Api\Http\Requests\Search\SearchRequest;
-use GetCandy\Api\Http\Transformers\Fractal\Search\SearchSuggestionTransformer;
+use GetCandy\Api\Core\Channels\Services\ChannelService;
+use GetCandy\Api\Core\Products\Services\ProductService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Http\Request;
+use GetCandy\Api\Core\Categories\Services\CategoryService;
+use GetCandy\Api\Http\Resources\Products\ProductCollection;
+use GetCandy\Api\Http\Resources\Categories\CategoryCollection;
+use GetCandy\Api\Http\Transformers\Fractal\Search\SearchSuggestionTransformer;
 
 class SearchController extends BaseController
 {
@@ -19,10 +23,16 @@ class SearchController extends BaseController
      */
     protected $channels;
 
-    public function __construct(ChannelService $channels, CategoryService $categories)
+    /**
+     * @var \GetCandy\Api\Core\Products\Services\ProductService
+     */
+    protected $products;
+
+    public function __construct(ChannelService $channels, CategoryService $categories, ProductService $products)
     {
         $this->channels = $channels;
         $this->categories = $categories;
+        $this->products = $products;
     }
 
     /**
@@ -76,17 +86,55 @@ class SearchController extends BaseController
             return $this->errorInternalError($e->getMessage());
         }
 
-        $results = app('api')->search()->getResults(
-            $results,
-            $request->get('search_type', 'product'),
-            $request->include,
-            $page ?: 1,
-            $request->category,
-            $request->user(),
-            $request->ids_only ?: false
-        );
 
-        return response($results, 200);
+        $ids = collect();
+
+        if ($results->count()) {
+            foreach ($results as $r) {
+                $ids->push($r->getSource()['id'] ?? null);
+            }
+        }
+
+        $searchResponse = $results->getResponse();
+        $meta = $searchResponse->getData();
+
+        if ($request->search_type == 'category') {
+            $models = $this->categories->getSearchedIds($ids, $this->parseIncludes($request->include));
+            $paginator = new LengthAwarePaginator(
+                $models,
+                $meta['hits']['total'],
+                $results->getQuery()->getParam('size'),
+                $page
+            );
+
+            $resource = new CategoryCollection($paginator);
+        } else {
+            $models = $this->products->getSearchedIds($ids, $this->parseIncludes($request->include));
+            $paginator = new LengthAwarePaginator(
+                $models,
+                $meta['hits']['total'],
+                $results->getQuery()->getParam('size'),
+                $page
+            );
+
+            $resource = new ProductCollection($paginator);
+        }
+
+        // $results = app('api')->search()->getResults(
+        //     $results,
+        //     $request->get('search_type', 'product'),
+        //     $request->include,
+        //     $page ?: 1,
+        //     $request->category,
+        //     $request->user(),
+        //     $request->ids_only ?: false
+        // );
+
+        return $resource->additional([
+            'meta' => [
+                'aggregations' => $meta['aggregations']
+            ],
+        ]);
     }
 
     /**

--- a/src/Http/Resources/Attributes/AttributeResource.php
+++ b/src/Http/Resources/Attributes/AttributeResource.php
@@ -29,7 +29,7 @@ class AttributeResource extends AbstractResource
     public function includes()
     {
         return [
-            'group' => ['data' => new AttributeGroupResource($this->whenLoaded('group'))],
+            'group' => $this->include('group', AttributeGroupResource::class),
         ];
     }
 }

--- a/src/Http/Resources/Products/ProductResource.php
+++ b/src/Http/Resources/Products/ProductResource.php
@@ -39,9 +39,9 @@ class ProductResource extends AbstractResource
     {
         return [
             'attributes' => new AttributeCollection($this->whenLoaded('attributes')),
-            'draft' => ['data' => new self($this->whenLoaded('draft'))],
-            'layout' => ['data' => new LayoutResource($this->whenLoaded('layout'))],
-            'published_parent' => ['data' => new self($this->whenLoaded('publishedParent'))],
+            'draft' => $this->include('draft', self::class),
+            'layout' => $this->include('layout', LayoutResource::class),
+            'published_parent' => $this->include('publishedParent', self::class),
             'assets' => new AssetCollection($this->whenLoaded('assets')),
             'family' => $this->include('family', ProductFamilyResource::class),
             'routes' => new RouteCollection($this->whenLoaded('routes')),


### PR DESCRIPTION
This PR includes a number of changes to the search for better performance.

### Scenario tested against 500k products

When hitting the `search` endpoint with includes `categories,channels,variants,assets.transforms,customerGroups,family`

Response time before = over 30s or DNF
Response time after = 40-200ms

---

## Channel scope & Customer group changes

Before the API was using a `whereHas` query on checking whether a row should be returned, this was adding weight to the response time so now we're using an inner join which has yielded good performance without any breaking changes.

## Removal of Fractal

The search endpoint was using fractal, we want to move away from this as it's difficult to eager load on included resources, so now we use Eloquent resources and can easily eager load what relations we want set. Also previously there was some hard coded includes being set on the search service to combat fractals limitations, these have been removed and are now added on the request as needed, resulting in a smaller response size.

## Aggregation helpers

When using fractal we was doing some weird transformer stuff on aggregations, specifically category aggregations, I've added a `parseAggregations` method on the Elastic provider which will take the result from Elasticsearch and parse into resources etc which should help make the search response make more sense. For example it will include the attribute resource so for help with displaying on the storefront. Not sure if this is the best place to have this, so I'm open to suggestions.

---

## Additional changes

Ability to set batch size on reindex
Updates to `ProductResource` and `AttributeResource` so relations don't show on response if they are not being included, helps bring down payload.