### PR TITLE
Feature/improved installation procedure

### DIFF
--- a/src/Console/Commands/InstallGetCandyCommand.php
+++ b/src/Console/Commands/InstallGetCandyCommand.php
@@ -52,14 +52,14 @@ class InstallGetCandyCommand extends Command
 
             $elasticsearch = $event->response['elasticsearch'];
 
-            if(! $elasticsearch['connected']) {
+            if (! $elasticsearch['connected']) {
                 $this->error('Unable to connect to elasticsearh');
                 $this->warn('Did you remember to configure the connection in config/getcandy.php?');
 
                 exit(1);
             }
 
-            if(! $elasticsearch['success']) {
+            if (! $elasticsearch['success']) {
                 $this->error("GetCandy requires Elasticsearch version 6.8(.x). You're running version {$elasticsearch['version']}");
 
                 exit(1);

--- a/src/Console/Commands/InstallGetCandyCommand.php
+++ b/src/Console/Commands/InstallGetCandyCommand.php
@@ -47,9 +47,23 @@ class InstallGetCandyCommand extends Command
             if (! $database['connected']) {
                 $this->error('Unable to connect to database');
 
-                return;
+                exit(1);
             }
-            $this->info('Preflight complete');
+
+            $elasticsearch = $event->response['elasticsearch'];
+
+            if(! $elasticsearch['connected']) {
+                $this->error('Unable to connect to elasticsearh');
+                $this->warn('Did you remember to configure the connection in config/getcandy.php?');
+
+                exit(1);
+            }
+
+            if(! $elasticsearch['success']) {
+                $this->error("GetCandy requires Elasticsearch version 6.8(.x). You're running version {$elasticsearch['version']}");
+
+                exit(1);
+            }
         });
 
         // Run the installer...

--- a/src/Installer/Runners/ChannelRunner.php
+++ b/src/Installer/Runners/ChannelRunner.php
@@ -14,7 +14,7 @@ class ChannelRunner extends AbstractRunner implements InstallRunnerContract
             return;
         }
 
-        $channel = $this->command->anticipate('Choose a new channel name e.g. webstore', ['webstore']);
+        $channel = $this->command->anticipate('Choose a new channel name e.g. webstore', ['webstore'], 'webstore');
         $channelUrl = $this->command->ask('Whats the storefront URL this channel points to? (leave blank if unsure)');
 
         DB::table('channels')->insert([

--- a/src/Installer/Runners/PreflightRunner.php
+++ b/src/Installer/Runners/PreflightRunner.php
@@ -35,7 +35,7 @@ class PreflightRunner extends AbstractRunner implements InstallRunnerContract
         } catch (HttpException $e) {
             $esVersion = null;
         }
-        
+
         event(new PreflightCompletedEvent([
             'api' => [
                 'version' => $apiVersion,

--- a/src/Installer/Runners/PreflightRunner.php
+++ b/src/Installer/Runners/PreflightRunner.php
@@ -3,6 +3,8 @@
 namespace GetCandy\Api\Installer\Runners;
 
 use DB;
+use Elastica\Client;
+use Elastica\Exception\Connection\HttpException;
 use GetCandy;
 use GetCandy\Api\Installer\Contracts\InstallRunnerContract;
 use GetCandy\Api\Installer\Events\PreflightCompletedEvent;
@@ -24,6 +26,19 @@ class PreflightRunner extends AbstractRunner implements InstallRunnerContract
             $dbVersion = null;
         }
 
+        try {
+
+            $elastica = new Client(config('getcandy.search.client_config.elastic'));
+
+            $result = $elastica->request('/');
+
+            $esVersion = $result->getData()['version']['number'];
+
+        } catch (HttpException $e) {
+            $esVersion = null;
+        }
+
+
         event(new PreflightCompletedEvent([
             'api' => [
                 'version' => $apiVersion,
@@ -34,6 +49,14 @@ class PreflightRunner extends AbstractRunner implements InstallRunnerContract
                 'connected' => $dbVersion ?? false,
                 'success' => (bool) $dbVersion,
             ],
+            'elasticsearch' => [
+                'version' => $esVersion,
+                'connected' => $esVersion ?? false,
+                'success' => $esVersion !== null
+                    && version_compare($esVersion, '6.9', '<')
+                    && version_compare($esVersion, '6.8', '>='),
+
+            ]
         ]));
 
         return $this;

--- a/src/Installer/Runners/PreflightRunner.php
+++ b/src/Installer/Runners/PreflightRunner.php
@@ -27,18 +27,15 @@ class PreflightRunner extends AbstractRunner implements InstallRunnerContract
         }
 
         try {
-
             $elastica = new Client(config('getcandy.search.client_config.elastic'));
 
             $result = $elastica->request('/');
 
             $esVersion = $result->getData()['version']['number'];
-
         } catch (HttpException $e) {
             $esVersion = null;
         }
-
-
+        
         event(new PreflightCompletedEvent([
             'api' => [
                 'version' => $apiVersion,
@@ -56,7 +53,7 @@ class PreflightRunner extends AbstractRunner implements InstallRunnerContract
                     && version_compare($esVersion, '6.9', '<')
                     && version_compare($esVersion, '6.8', '>='),
 
-            ]
+            ],
         ]));
 
         return $this;

--- a/src/Installer/Runners/UserRunner.php
+++ b/src/Installer/Runners/UserRunner.php
@@ -37,7 +37,7 @@ class UserRunner extends AbstractRunner implements InstallRunnerContract
 
         $name = $this->command->ask('What\'s your name?');
 
-        $firstAndLast = explode(' ', $name);
+        [$firstName, $lastName] = explode(' ', $name, 2);
 
         $email = $this->command->ask("What's your email?");
 
@@ -64,6 +64,10 @@ class UserRunner extends AbstractRunner implements InstallRunnerContract
         ]);
 
         $user->save();
+        $user->details()->updateOrCreate([
+            'firstname' => $firstName,
+            'lastname' => $lastName,
+        ]);
 
         return $user;
     }

--- a/src/Installer/Runners/UserRunner.php
+++ b/src/Installer/Runners/UserRunner.php
@@ -37,7 +37,7 @@ class UserRunner extends AbstractRunner implements InstallRunnerContract
 
         $name = $this->command->ask('What\'s your name?');
 
-        [$firstName, $lastName] = explode(' ', $name, 2);
+        $nameParts = explode(' ', $name, 2);
 
         $email = $this->command->ask("What's your email?");
 
@@ -65,8 +65,8 @@ class UserRunner extends AbstractRunner implements InstallRunnerContract
 
         $user->save();
         $user->details()->updateOrCreate([
-            'firstname' => $firstName,
-            'lastname' => $lastName,
+            'firstname' => $nameParts[0],
+            'lastname' => $nameParts[1] ?? null,
         ]);
 
         return $user;


### PR DESCRIPTION
This PR addresses some minor installation requirements that some users express difficulties with during installation.

Added is:
 - storing of the users first and last name in the `user_details` table
 - default channel name (errors occur if you by accident just press enter)
 - preflight check of Elasticsearch connection and version
 - explicit exiting with generic error code when preflight conditions are not met