### PR TITLE
Add base controller parsing

### DIFF
--- a/src/Http/Controllers/Categories/CategoryController.php
+++ b/src/Http/Controllers/Categories/CategoryController.php
@@ -197,7 +197,7 @@ class CategoryController extends BaseController
         \DB::transaction(function () use ($category) {
             Drafting::with('categories')->publish($category);
         });
-        
+
         return new CategoryResource($category->load($this->parseIncludes($request->include)));
     }
 


### PR DESCRIPTION
Some references to `$request->include` were not parsed correctly, which caused issues across several functions like drafting, product and category viewing.