### PR TITLE
[RFC][WIP] Initial Route Facade work

### DIFF
--- a/config/hashids.php
+++ b/config/hashids.php
@@ -114,6 +114,11 @@ return [
             'salt' => env('HASHIDS_TAX_SALT', 'tax'),
             'length' => 8,
         ],
+        'route' => [
+            'alphabet' => $alphabet,
+            'salt' => env('HASHIDS_ROUTE_SALT', 'route'),
+            'length' => 8,
+        ],
         'user' => [
             'alphabet' => $alphabet,
             'salt' => env('HASHIDS_USER_SALT', 'user'),

--- a/src/Core/Facades/Route.php
+++ b/src/Core/Facades/Route.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GetCandy\Api\Core\Facades;
+
+use GetCandy\Api\Core\GetCandy;
+use Illuminate\Support\Facades\Facade;
+
+class Route extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return Route::class;
+    }
+}

--- a/src/Core/Products/Factories/ProductVariantFactory.php
+++ b/src/Core/Products/Factories/ProductVariantFactory.php
@@ -14,6 +14,11 @@ class ProductVariantFactory extends AbstractFactory implements ProductVariantInt
      */
     protected $variant;
 
+    public function getModelReference()
+    {
+        return ProductVariant::class;
+    }
+
     public function init(ProductVariant $variant)
     {
         $this->variant = $variant;

--- a/src/Core/Routes/Models/Route.php
+++ b/src/Core/Routes/Models/Route.php
@@ -16,7 +16,7 @@ class Route extends BaseModel
      *
      * @var string
      */
-    protected $hashids = 'main';
+    protected $hashids = 'route';
 
     /**
      * The attributes that are mass assignable.

--- a/src/Core/Routes/RouteFactory.php
+++ b/src/Core/Routes/RouteFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GetCandy\Api\Core\Routes;
+
+use GetCandy\Api\Core\Routes\Models\Route;
+use GetCandy\Api\Core\Scaffold\AbstractFactory;
+
+class RouteFactory extends AbstractFactory implements RouteFactoryInterface
+{
+    public function get($slug, $elementType, $path = null)
+    {
+        return Route::whereSlug($slug)->wherePath($path)->whereElementType($elementType)->first();
+    }
+
+    public function getModelReference()
+    {
+        return Route::class;
+    }
+}

--- a/src/Core/Routes/RouteFactoryInterface.php
+++ b/src/Core/Routes/RouteFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GetCandy\Api\Core\Routes;
+
+interface RouteFactoryInterface
+{
+    public function get($slug, $elementType, $path = null);
+}

--- a/src/Core/Scaffold/AbstractFactory.php
+++ b/src/Core/Scaffold/AbstractFactory.php
@@ -26,4 +26,7 @@ abstract class AbstractFactory
         $this->calculator = $calculator;
         $this->api = $api;
     }
+
+    abstract function getModelReference();
+
 }

--- a/src/Core/Scaffold/AbstractFactory.php
+++ b/src/Core/Scaffold/AbstractFactory.php
@@ -29,4 +29,15 @@ abstract class AbstractFactory
 
     abstract function getModelReference();
 
+    public function encodeId($id)
+    {
+        $class = $this->getModelReference();
+        return (new $class)->encode($id);
+    }
+
+    public function decodeId($id)
+    {
+        $class = $this->getModelReference();
+        return (new $class)->decodeId($id);
+    }
 }

--- a/src/Providers/ApiServiceProvider.php
+++ b/src/Providers/ApiServiceProvider.php
@@ -9,6 +9,7 @@ use GetCandy\Api\Core\Currencies\CurrencyConverter;
 use GetCandy\Api\Core\Factory;
 use GetCandy\Api\Core\GetCandy;
 use GetCandy\Api\Core\Users\Contracts\UserContract;
+use GetCandy\Api\Providers\RouteServiceProvider;
 use GetCandy\Api\Core\Users\Services\UserService;
 use GetCandy\Api\Http\Middleware\DetectHubRequestMiddleware;
 use GetCandy\Api\Http\Middleware\SetChannelMiddleware;
@@ -65,6 +66,7 @@ class ApiServiceProvider extends ServiceProvider
             TaxServiceProvider::class,
             UtilServiceProvider::class,
             ReportsServiceProvider::class,
+            RouteServiceProvider::class,
             RecycleBinServiceProvider::class,
         ];
         foreach ($providers as $provider) {

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GetCandy\Api\Providers;
+
+use GetCandy\Api\Core\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use GetCandy\Api\Core\Routes\RouteFactory;
+use GetCandy\Api\Core\Routes\RouteFactoryInterface;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind(RouteFactoryInterface::class, function ($app) {
+            return $app->make(RouteFactory::class);
+        });
+
+        $this->app->bind(Route::class, function ($app) {
+            return $app->make(RouteFactoryInterface::class);
+        });
+    }
+}

--- a/tests/Unit/Facades/RouteFacadeTest.php
+++ b/tests/Unit/Facades/RouteFacadeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Routes;
+
+use Tests\TestCase;
+use GetCandy\Api\Core\Facades\Route;
+use GetCandy\Api\Core\Routes\RouteFactory;
+
+/**
+ * @group routes
+ */
+class RouteFacadeTest extends TestCase
+{
+    public function test_can_be_resolved_from_ioc()
+    {
+        $instance = $this->app->make(Route::class);
+        $this->assertInstanceOf(RouteFactory::class, $instance);
+    }
+}

--- a/tests/Unit/Routes/RouteFactoryTest.php
+++ b/tests/Unit/Routes/RouteFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit\Routes;
+
+use DB;
+use Tests\TestCase;
+use GetCandy\Api\Core\Routes\Models\Route;
+use GetCandy\Api\Core\Routes\RouteFactory;
+use GetCandy\Api\Core\Routes\RouteFactoryInterface;
+
+/**
+ * @group routes
+ */
+class RouteFactoryTest extends TestCase
+{
+    public function test_can_be_resolved_from_ioc()
+    {
+        $factory = $this->app->make(RouteFactoryInterface::class);
+        $this->assertInstanceOf(RouteFactory::class, $factory);
+    }
+
+    public function test_can_encode_and_decode_ids_from_config()
+    {
+        $factory = $this->app->make(RouteFactoryInterface::class);
+        $config = config('hashids.connections.route');
+
+        $encodedId = $factory->encodeId(1);
+
+        $this->assertIsString($encodedId);
+        $this->assertEquals($config['length'], strlen($encodedId));
+
+        $decodedId = $factory->decodeId($encodedId);
+
+        $this->assertIsNumeric($decodedId);
+        $this->assertEquals(1, $decodedId);
+    }
+
+    public function test_can_get_route_by_slug_from_database()
+    {
+        $newRouteId = DB::table('routes')->insertGetId([
+            'element_id' => 1,
+            'element_type' => 'Foobar',
+            'slug' => 'foobar'
+        ]);
+
+        $factory = $this->app->make(RouteFactoryInterface::class);
+
+        $route = $factory->get('foobar', 'Foobar');
+
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals($newRouteId, $route->id);
+    }
+
+    public function test_can_get_route_by_slug_and_path()
+    {
+        DB::table('routes')->insertGetId([
+            'element_id' => 1,
+            'element_type' => 'Foobar',
+            'slug' => 'bar',
+        ]);
+
+        $newRouteId = DB::table('routes')->insertGetId([
+            'element_id' => 1,
+            'element_type' => 'Foobar',
+            'slug' => 'bar',
+            'path' => 'foo'
+        ]);
+
+        $factory = $this->app->make(RouteFactoryInterface::class);
+
+        $route = $factory->get('bar', 'Foobar', 'foo');
+
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals($newRouteId, $route->id);
+    }
+
+    public function test_can_get_route_by_slug_and_path_and_element()
+    {
+        DB::table('routes')->insertGetId([
+            'element_id' => 1,
+            'element_type' => 'Foo',
+            'slug' => 'foo',
+        ]);
+
+        $expectedRouteId = DB::table('routes')->insertGetId([
+            'element_id' => 1,
+            'element_type' => 'Bar',
+            'slug' => 'foo',
+        ]);
+
+        $factory = $this->app->make(RouteFactoryInterface::class);
+
+        $route = $factory->get('foo', 'Bar');
+
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals($expectedRouteId, $route->id);
+    }
+}


### PR DESCRIPTION
This PR aims to start the process of adding a Facade service layer for database Routes.

The idea is that you can import the facade like so:

```
use GetCandy\Api\Core\Facades\Route;
```

Once imported you'd be able to interact with the routes service layer like so:

```
$route = Route::get($slug, $element, $path);
```

This is very much in it's infancy and is open to change.