### PR TITLE
Add template support for routing

### DIFF
--- a/src/Core/GetCandy.php
+++ b/src/Core/GetCandy.php
@@ -92,8 +92,16 @@ class GetCandy
 
     public static function router(array $options = [], $callback = null)
     {
-        $callback = $callback ?: function ($router) {
-            $router->all();
+        $callback = $callback ?: function ($router) use ($options) {
+            $template = $options['template'] ?? null;
+            if ($template) {
+                $method = 'template' . ucfirst($template);
+                if (method_exists($router, $method)) {
+                    $router->{$method}();
+                }
+            } else {
+                $router->all();
+            }
         };
 
         $defaultOptions = [

--- a/src/Core/GetCandy.php
+++ b/src/Core/GetCandy.php
@@ -95,7 +95,7 @@ class GetCandy
         $callback = $callback ?: function ($router) use ($options) {
             $template = $options['template'] ?? null;
             if ($template) {
-                $method = 'template' . ucfirst($template);
+                $method = 'template'.ucfirst($template);
                 if (method_exists($router, $method)) {
                     $router->{$method}();
                 }

--- a/src/Core/RouteRegistrar.php
+++ b/src/Core/RouteRegistrar.php
@@ -45,8 +45,32 @@ class RouteRegistrar
         $this->router->group([], __DIR__.'/../../routes/api.client.php');
     }
 
+    /**
+     * Register the auth routes
+     *
+     * @return  void
+     */
     public function auth()
     {
         $this->router->group([], __DIR__.'/../../routes/api.php');
+    }
+
+    /**
+     * Provide a sanctum template to use
+     *
+     * @return  void
+     */
+    public function templateSanctum()
+    {
+        $this->router->group([
+            'middleware' => ['auth:sanctum', 'api']
+        ], function () {
+            $this->auth();
+        });
+        $this->router->group([
+            'middleware' => ['api']
+        ], function () {
+            $this->guest();
+        });
     }
 }

--- a/src/Core/RouteRegistrar.php
+++ b/src/Core/RouteRegistrar.php
@@ -46,7 +46,7 @@ class RouteRegistrar
     }
 
     /**
-     * Register the auth routes
+     * Register the auth routes.
      *
      * @return  void
      */
@@ -56,19 +56,19 @@ class RouteRegistrar
     }
 
     /**
-     * Provide a sanctum template to use
+     * Provide a sanctum template to use.
      *
      * @return  void
      */
     public function templateSanctum()
     {
         $this->router->group([
-            'middleware' => ['auth:sanctum', 'api']
+            'middleware' => ['auth:sanctum', 'api'],
         ], function () {
             $this->auth();
         });
         $this->router->group([
-            'middleware' => ['api']
+            'middleware' => ['api'],
         ], function () {
             $this->guest();
         });


### PR DESCRIPTION
This change adds the ability to specify routing "templates" for dev's to use when installing/setting up GetCandy.

This would aim to reduce the possibility to getting middleware etc wrong and provides and easier to understand syntax. 

So before a user would set up routes (for sanctum) like:

```
GetCandy::router([
    'prefix' => 'api/v1'
], function ($registrar) {
    Route::group([
         'middleware' => ['auth:sanctum', 'api']
    ], function () use ($registrar) {
        $registrar->auth();
    });
    Route::group([
        'middleware' => ['api']
    ], function () use ($registrar) {
        $registrar->guest();
    });
});
```

Now with templates they just need to do:

```
GetCandy::router([
    'prefix' => 'api/v1',
    'template' => 'sanctum',
]);
```

Which, under the hood does the same thing as the more verbose example above, just dev's don't have to worry about it. But still allows them to do more complex routing if they want.