### PR TITLE
Feat/channel sandbox setting

### DIFF
--- a/routes/api.client.php
+++ b/routes/api.client.php
@@ -11,13 +11,12 @@
 */
 
 $router->get('/', function () {
-    $channel = app()->make(GetCandy\Api\Core\Channels\Interfaces\ChannelFactoryInterface::class);
     $currency = app()->make(GetCandy\Api\Core\Currencies\Interfaces\CurrencyConverterInterface::class);
 
     return response()->json([
         'version' => GetCandy::version(),
         'locale' => app()->getLocale(),
-        'channel' => new \GetCandy\Api\Core\Channels\Resources\ChannelResource($channel->getChannel()),
+        'channel' => GetCandy\Api\Core\Channels\Actions\FetchCurrentChannel::run(),
         'currency' => new GetCandy\Api\Http\Resources\Currencies\CurrencyResource($currency->get()),
     ]);
 });

--- a/src/Core/Channels/Actions/FetchCurrentChannel.php
+++ b/src/Core/Channels/Actions/FetchCurrentChannel.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace GetCandy\Api\Core\Channels\Actions;
+
+use GetCandy\Api\Core\Channels\Interfaces\ChannelFactoryInterface;
+use GetCandy\Api\Core\Scaffold\AbstractAction;
+
+class FetchCurrentChannel extends AbstractAction
+{
+    /**
+     * Determine if the user is authorized to make this action.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the action.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'handle' => 'string|nullable',
+        ];
+    }
+
+    /**
+     * Execute the action and return a result.
+     *
+     * @return void
+     */
+    public function handle(ChannelFactoryInterface $factory)
+    {
+        return $factory->getChannel();
+    }
+}

--- a/src/Core/GetCandy.php
+++ b/src/Core/GetCandy.php
@@ -3,10 +3,12 @@
 namespace GetCandy\Api\Core;
 
 use File;
-use GetCandy\Api\Exceptions\InvalidServiceException;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Route;
+use GetCandy\Api\Exceptions\InvalidServiceException;
+use GetCandy\Api\Core\Channels\Actions\SetCurrentChannel;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use GetCandy\Api\Core\Channels\Actions\FetchCurrentChannel;
 
 class GetCandy
 {
@@ -61,6 +63,18 @@ class GetCandy
         $this->isHubRequest = $bool;
 
         return $this;
+    }
+
+    public static function onChannel($channel, \Closure $closure)
+    {
+        $current = FetchCurrentChannel::run();
+        SetCurrentChannel::run([
+            'handle' => $channel,
+        ]);
+        $closure();
+        SetCurrentChannel::run([
+            'handle' => $current->handle,
+        ]);
     }
 
     /**

--- a/src/Core/Scopes/ChannelScope.php
+++ b/src/Core/Scopes/ChannelScope.php
@@ -25,7 +25,7 @@ class ChannelScope extends AbstractScope
             $builder->addSelect("{$model->getTable()}.*")->join($relation->getTable(), function ($join) use ($relation, $model, $channel) {
                 $join->on("{$model->getTable()}.id", '=', $relation->getExistenceCompareKey())
                 ->where("{$relation->getTable()}.channel_id", $channel->getChannel()->id)
-                ->where("{$relation->getTable()}.published_at", '<=', Carbon::now());
+                ->whereDate("{$relation->getTable()}.published_at", '<=', now());
             })->groupBy($relation->getExistenceCompareKey());
         });
     }


### PR DESCRIPTION
This adds functionality to allow a developer to run code for a specific channel without it affect other area's of the system they want to remain on the currently set channel.

Usage is as follows, assuming current channel is `webstore`:

```
use GetCandy;

// Code runs on webstore

GetCandy::onChannel('another-channel', function () {
    // Code runs on another-channel
});

// Code runs on webstore
```

At the moment we're using a singleton to set the global channel, this PR gets the current before the code is run, updates to the channel that is passed and then reverts back to what it was. 

We may change this down the line and this function would need to be updated potentially, but as it stands I can't think of a way around doing this without having to make a lot of changes. This seemed to work on some simple tests I did and ofc we can add some unit tests to ensure it's working as intended.