### PR TITLE
Don’t sync to retail if customer_groups empty

### DIFF
--- a/src/Core/Users/Services/UserService.php
+++ b/src/Core/Users/Services/UserService.php
@@ -163,9 +163,6 @@ class UserService extends BaseService implements UserContract
         if (! empty($data['customer_groups'])) {
             $groupData = app('api')->customerGroups()->getDecodedIds($data['customer_groups']);
             $user->groups()->sync($groupData);
-        } else {
-            $default = app('api')->customerGroups()->getDefaultRecord();
-            $user->groups()->attach($default);
         }
 
         $user->save();


### PR DESCRIPTION
This removes attaching retail (default) to the customer group if no customer groups are passed through on update.

Creating is left as is.