### PR TITLE
Fixed compatibility with composer version 2

### DIFF
--- a/src/Core/GetCandy.php
+++ b/src/Core/GetCandy.php
@@ -42,7 +42,9 @@ class GetCandy
     public static function version()
     {
         try {
-            $packages = collect(json_decode(File::get(base_path('vendor/composer/installed.json'))));
+            // Composer version 2 support
+            $packageManifest = json_decode(File::get(base_path('vendor/composer/installed.json')));
+            $packages = is_array($packageManifest) ? collect($packageManifest) : collect($packageManifest->packages);
         } catch (FileNotFoundException $e) {
             return 'Unknown';
         }


### PR DESCRIPTION
Structure of the installed.json file has changed, seems to return an object not an array anymore. Fix includes backwards compatibility.