### PR TITLE
Composer 2 Support

### DIFF
--- a/src/Core/GetCandy.php
+++ b/src/Core/GetCandy.php
@@ -47,7 +47,7 @@ class GetCandy
             return 'Unknown';
         }
 
-        return $packages->first(function ($p) {
+        return ($packages->has('packages') ? collect($packages->get('packages')) : $packages)->first(function ($p) {
             return $p->name === 'getcandy/candy-api';
         })->version;
     }


### PR DESCRIPTION
Composer 2 has the `packages` and `dev` keys now and installed packages are located under the first one.