### PR TITLE
Added specific route to fetch Customer Groups to fix Hub request

### DIFF
--- a/routes/api.client.php
+++ b/routes/api.client.php
@@ -26,6 +26,7 @@ $router->get('products', 'Products\ProductController@index');
 $router->group([
     'prefix' => 'customers',
 ], function ($group) {
+    $group->get('groups', '\GetCandy\Api\Core\Customers\Actions\FetchCustomerGroups');
     $group->get('{encoded_id}', '\GetCandy\Api\Core\Customers\Actions\FetchCustomer');
     $group->put('{encoded_id}', '\GetCandy\Api\Core\Customers\Actions\UpdateCustomer');
     $group->post('/', '\GetCandy\Api\Core\Customers\Actions\CreateCustomer');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Description**
<!-- Provide a clear description of your changes/what they achieve -->
A specific route was added to support the request by the hub for `order-processing/dashboard` request.
The missing route made the `FetchCustomer` Action respond as the router thought `groups` was a parameter (`encoded_id`) and this made the Hub break on a fresh install of both. 

**Checks**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Works with a fresh install
- [ ] Documentation updated
  - [ ] Changelog
  - [ ] Upgrade guide
  - [ ] Do these changes impact the hub and require a new version
