### PR TITLE
Reference NodeTrait method for setting parent ID of Category

### DIFF
--- a/src/Core/Categories/Models/Category.php
+++ b/src/Core/Categories/Models/Category.php
@@ -110,11 +110,7 @@ class Category extends BaseModel
             return;
         }
 
-        if ($value) {
-            $this->appendToNode($this->newScopedQuery()->withDrafted()->findOrFail($value));
-        } else {
-            $this->makeRoot();
-        }
+        $this->setParentId($value);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This minor fix addressed issue #332 

**Description**
<!-- Provide a clear description of your changes/what they achieve -->

Instead of using the mutators scope for setting the parent ID of a child category, which failed, this utilizes the trait method provided by the nestedset package.


**Checks**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Works with a fresh install
- [ ] Documentation updated
  - [ ] Changelog
  - [ ] Upgrade guide
  - [ ] Do these changes impact the hub and require a new version
