### PR TITLE
Language Refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ You can do this by running `php artisan candy:products:reindex` and `php artisan
 - Slight optimisation for Elasticsearch and the fields it returns
 - Drafting and Publishing of a draft will now run in a transaction, you can also extend the drafting functionality in your plugins.
 - SKU uses `trim` when being saved
-
+- Languages have been refactored and simplified so now we only rely on `code` and have removed `lang` and `iso` columns.
+- When detecting the language to use for API responses, we now parse the `accept-language` header properly.
 ### 🏗️ Additions
 
 - Added endpoint to get a payment provider via it's given ID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ You can do this by running `php artisan candy:products:reindex` and `php artisan
 - Slight optimisation for Elasticsearch and the fields it returns
 - Drafting and Publishing of a draft will now run in a transaction, you can also extend the drafting functionality in your plugins.
 - SKU uses `trim` when being saved
-- Languages have been refactored and simplified so now we only rely on `code` and have removed `lang` and `iso` columns.
+- Languages have been refactored and simplified so now we only rely on `code`. The `lang` column has been replaced by `code` and the `iso` column has been removed.
 - When detecting the language to use for API responses, we now parse the `accept-language` header properly.
 ### 🏗️ Additions
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "doctrine/dbal": "2.9.2",
         "ruflin/elastica": "^7.0",
         "spatie/laravel-permission": "^3.17",
+        "supportpal/accept-language-parser": "^0.1",
         "vinkla/hashids": "^9.0",
         "paypal/rest-api-sdk-php": "*",
         "laravel/helpers": "1.3.0",

--- a/database/factories/LanguageFactory.php
+++ b/database/factories/LanguageFactory.php
@@ -20,8 +20,7 @@ $factory->define(Language::class, function (Faker $faker) {
 
     return [
         'name' => $name,
-        'lang' => ucfirst($name),
-        'iso' => Str::slug($name),
+        'code' => Str::slug($name),
         'default' => $faker->boolean,
         'enabled' => $faker->boolean,
     ];

--- a/database/factories/LanguageFactory.php
+++ b/database/factories/LanguageFactory.php
@@ -2,7 +2,6 @@
 
 use Faker\Generator as Faker;
 use GetCandy\Api\Core\Languages\Models\Language;
-use Illuminate\Support\Str;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,11 +15,9 @@ use Illuminate\Support\Str;
 */
 
 $factory->define(Language::class, function (Faker $faker) {
-    $name = $faker->unique()->company;
-
     return [
-        'name' => $name,
-        'code' => Str::slug($name),
+        'name' => $faker->unique()->country,
+        'code' => $faker->languageCode,
         'default' => $faker->boolean,
         'enabled' => $faker->boolean,
     ];

--- a/database/migrations/2021_03_17_121602_refactor_languages_table.php
+++ b/database/migrations/2021_03_17_121602_refactor_languages_table.php
@@ -1,10 +1,8 @@
 <?php
 
-use Spatie\Permission\Models\Role;
-use Illuminate\Support\Facades\Schema;
-use Spatie\Permission\Models\Permission;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class RefactorLanguagesTable extends Migration
 {

--- a/database/migrations/2021_03_17_121602_refactor_languages_table.php
+++ b/database/migrations/2021_03_17_121602_refactor_languages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Spatie\Permission\Models\Role;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RefactorLanguagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('languages', function (Blueprint $table) {
+            $table->dropColumn('iso');
+        });
+        Schema::table('languages', function (Blueprint $table) {
+            $table->renameColumn('lang', 'code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        // One way migration
+    }
+}

--- a/database/seeds/LanguageTableSeeder.php
+++ b/database/seeds/LanguageTableSeeder.php
@@ -15,15 +15,13 @@ class LanguageTableSeeder extends Seeder
     public function run()
     {
         Language::forceCreate([
-            'lang' => 'en',
-            'iso' => 'gb',
+            'code' => 'en',
             'name' => 'English',
             'default' => true,
         ]);
 
         Language::forceCreate([
-            'lang' => 'fr',
-            'iso' => 'fr',
+            'code' => 'fr',
             'name' => 'Français',
             'default' => false,
         ]);

--- a/openapi/languages/models/Language.yaml
+++ b/openapi/languages/models/Language.yaml
@@ -7,7 +7,7 @@ properties:
   code:
     type: string
     example: en
-    pattern: '^[a-zA-Z0-9 *,-.;=]*$'
+    pattern: '^[a-zA-Z0-9-]*$'
   name:
     type: string
     example: English

--- a/openapi/languages/models/Language.yaml
+++ b/openapi/languages/models/Language.yaml
@@ -4,12 +4,10 @@ properties:
   id:
     type: string
     example: y3g6v91o
-  iso:
-    type: string
-    example: gb
-  lang:
+  code:
     type: string
     example: en
+    pattern: '^[a-zA-Z0-9 *,-.;=]*$'
   name:
     type: string
     example: English

--- a/openapi/languages/paths/languages.id.yaml
+++ b/openapi/languages/paths/languages.id.yaml
@@ -40,8 +40,7 @@ put:
                 data:
                   id: 6z8m9gmj
                   name: English
-                  lang: en
-                  iso: gb
+                  code: en
                   default: true
                   enabled: true
                   current: false

--- a/src/Core/Languages/Actions/CreateLanguage.php
+++ b/src/Core/Languages/Actions/CreateLanguage.php
@@ -31,7 +31,7 @@ class CreateLanguage extends AbstractAction
                 'string',
                 'unique:languages,code',
                 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
-                'regex:/^[a-zA-Z0-9 *,-.;=]*$/'
+                'regex:/^[a-zA-Z0-9 *,-.;=]*$/',
             ],
             'name' => 'required|string',
             'default' => 'boolean',

--- a/src/Core/Languages/Actions/CreateLanguage.php
+++ b/src/Core/Languages/Actions/CreateLanguage.php
@@ -31,7 +31,7 @@ class CreateLanguage extends AbstractAction
                 'string',
                 'unique:languages,code',
                 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
-                'regex:/^[a-zA-Z0-9 *,-.;=]*$/',
+                'regex:/^[a-zA-Z0-9-]*$/',
             ],
             'name' => 'required|string',
             'default' => 'boolean',

--- a/src/Core/Languages/Actions/CreateLanguage.php
+++ b/src/Core/Languages/Actions/CreateLanguage.php
@@ -26,8 +26,13 @@ class CreateLanguage extends AbstractAction
     public function rules()
     {
         return [
-            'lang' => 'required|string',
-            'iso' => 'required|string|unique:languages,iso',
+            'code' => [
+                'required',
+                'string',
+                'unique:languages,code',
+                // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
+                'regex:/^[a-zA-Z0-9 *,-.;=]*$/'
+            ],
             'name' => 'required|string',
             'default' => 'boolean',
             'enabled' => 'boolean',

--- a/src/Core/Languages/Models/Language.php
+++ b/src/Core/Languages/Models/Language.php
@@ -51,6 +51,7 @@ class Language extends BaseModel
         if (! is_array($code)) {
             $code = [$code];
         }
+
         return $query->whereIn('code', $code);
     }
 }

--- a/src/Core/Languages/Models/Language.php
+++ b/src/Core/Languages/Models/Language.php
@@ -19,7 +19,7 @@ class Language extends BaseModel
      * @var array
      */
     protected $fillable = [
-        'lang', 'iso', 'name', 'default', 'enabled',
+        'code', 'name', 'default', 'enabled',
     ];
 
     public function scopeDefault($query)
@@ -48,6 +48,9 @@ class Language extends BaseModel
 
     public function scopeCode($query, $code)
     {
-        return $query->whereIso($code);
+        if (! is_array($code)) {
+            $code = [$code];
+        }
+        return $query->whereIn('code', $code);
     }
 }

--- a/src/Core/Languages/Resources/LanguageResource.php
+++ b/src/Core/Languages/Resources/LanguageResource.php
@@ -11,8 +11,7 @@ class LanguageResource extends AbstractResource
         return [
             'id' => $this->encoded_id,
             'name' => $this->name,
-            'lang' => $this->lang,
-            'iso' => $this->iso,
+            'code' => $this->code,
             'default' => (bool) $this->default,
             'enabled' => (bool) $this->enabled,
             'current' => (bool) $this->current,

--- a/src/Core/Search/Drivers/Elasticsearch/Actions/FetchIndex.php
+++ b/src/Core/Search/Drivers/Elasticsearch/Actions/FetchIndex.php
@@ -43,6 +43,7 @@ class FetchIndex extends Action
         $indexes = [];
         $prefix = config('getcandy.search.index_prefix', 'getcandy');
         foreach ($this->languages as $language) {
+            $language = strtolower($language);
             $index = $client->getIndex(
                 "{$prefix}_{$this->type}_{$language}_{$this->uuid}"
             );

--- a/src/Core/Search/Drivers/Elasticsearch/Actions/IndexProducts.php
+++ b/src/Core/Search/Drivers/Elasticsearch/Actions/IndexProducts.php
@@ -53,7 +53,7 @@ class IndexProducts extends Action
 
         $languages = FetchLanguages::run([
             'paginate' => false,
-        ])->pluck('lang');
+        ])->pluck('code');
 
         $customerGroups = FetchCustomerGroups::run([
             'paginate' => false,
@@ -91,6 +91,10 @@ class IndexProducts extends Action
             $docs = collect($documents[$index->language] ?? [])->map(function ($document) {
                 return new Document($document->getId(), $document->getData());
             });
+
+            if (!$docs->count()) {
+                continue;
+            }
 
             $bulk = new Bulk($client);
             $bulk->setIndex($index->actual);

--- a/src/Core/Search/Drivers/Elasticsearch/Actions/IndexProducts.php
+++ b/src/Core/Search/Drivers/Elasticsearch/Actions/IndexProducts.php
@@ -92,7 +92,7 @@ class IndexProducts extends Action
                 return new Document($document->getId(), $document->getData());
             });
 
-            if (!$docs->count()) {
+            if (! $docs->count()) {
                 continue;
             }
 

--- a/src/Core/Search/Providers/Elastic/Indexer.php
+++ b/src/Core/Search/Providers/Elastic/Indexer.php
@@ -59,7 +59,7 @@ class Indexer
         $aliases = [];
 
         foreach ($languages as $language) {
-            $alias = $index.'_'.$language->lang;
+            $alias = $index.'_'.$language->code;
             $newIndex = $alias."_{$suffix}";
             $this->createIndex($alias."_{$suffix}", $type);
             $aliases[$alias] = $alias."_{$suffix}";
@@ -195,7 +195,7 @@ class Indexer
         $indexables = $type->getIndexDocument($model);
 
         foreach ($langs as $lang) {
-            $alias = $index.'_'.$lang->lang;
+            $alias = $index.'_'.$lang->code;
 
             $indices = $status->getIndicesWithAlias($alias);
 
@@ -235,7 +235,7 @@ class Indexer
             $indexables = $type->getIndexDocument($model);
 
             foreach ($langs as $lang) {
-                $alias = $index.'_'.$lang->lang;
+                $alias = $index.'_'.$lang->code;
 
                 $indices = $status->getIndicesWithAlias($alias);
 

--- a/src/Core/Search/Providers/Elastic/InteractsWithIndex.php
+++ b/src/Core/Search/Providers/Elastic/InteractsWithIndex.php
@@ -53,7 +53,7 @@ trait InteractsWithIndex
     {
         $defaultLang = FetchDefaultLanguage::run();
 
-        return $this->getBaseIndexName()."_{$defaultLang->lang}";
+        return $this->getBaseIndexName()."_{$defaultLang->code}";
     }
 
     /**

--- a/src/Core/Traits/HasAttributes.php
+++ b/src/Core/Traits/HasAttributes.php
@@ -59,7 +59,7 @@ trait HasAttributes
             return;
         } elseif (is_null($this->attribute_data[$handle][$channel][$userLocale])) {
             $channel = 'webstore';
-            $locale = $locale->lang;
+            $locale = $locale->code;
         }
     }
 
@@ -126,7 +126,7 @@ trait HasAttributes
             'paginate' => false,
         ]);
         foreach ($languages as $lang) {
-            $languagesArray[$lang->lang] = null;
+            $languagesArray[$lang->code] = null;
         }
         // Get our channels
         $channels = FetchChannels::run([

--- a/src/Http/Middleware/SetLocaleMiddleware.php
+++ b/src/Http/Middleware/SetLocaleMiddleware.php
@@ -21,18 +21,18 @@ class SetLocaleMiddleware
         $defaultLanguage = FetchDefaultLanguage::run();
         $parser = new Parser($request->header('accept-language'));
 
-        $locale = collect($parser->parse())->first();
+        $language = collect($parser->parse())->first();
 
         $code = $defaultLanguage->code;
-        if ($locale) {
-            $code = $locale->code();
+        if ($language) {
+            $code = $language->code();
         }
 
-        $language = FetchEnabledLanguageByCode::run([
+        $languageModel = FetchEnabledLanguageByCode::run([
             'code' => $code,
         ]);
 
-        if (! $language) {
+        if (! $languageModel) {
             $code = $defaultLanguage->code;
         }
 

--- a/src/Http/Middleware/SetLocaleMiddleware.php
+++ b/src/Http/Middleware/SetLocaleMiddleware.php
@@ -2,11 +2,10 @@
 
 namespace GetCandy\Api\Http\Middleware;
 
-use Locale;
 use Closure;
-use SupportPal\AcceptLanguageParser\Parser;
 use GetCandy\Api\Core\Languages\Actions\FetchDefaultLanguage;
 use GetCandy\Api\Core\Languages\Actions\FetchEnabledLanguageByCode;
+use SupportPal\AcceptLanguageParser\Parser;
 
 class SetLocaleMiddleware
 {
@@ -33,7 +32,7 @@ class SetLocaleMiddleware
             'code' => $code,
         ]);
 
-        if (!$language) {
+        if (! $language) {
             $code = $defaultLanguage->code;
         }
 

--- a/src/Http/Requests/Attributes/CreateRequest.php
+++ b/src/Http/Requests/Attributes/CreateRequest.php
@@ -27,7 +27,7 @@ class CreateRequest extends FormRequest
     {
         return [
             'group_id' => 'required',
-            'name' => 'array|required|valid_locales',
+            'name' => 'array|required|valid_language',
             'handle' => 'required|unique:attributes,handle',
         ];
     }

--- a/src/Http/Requests/Attributes/UpdateRequest.php
+++ b/src/Http/Requests/Attributes/UpdateRequest.php
@@ -28,7 +28,7 @@ class UpdateRequest extends FormRequest
         $decodedId = GetCandy::attributes()->getDecodedId($this->attribute);
 
         return [
-            'name' => 'required|array|valid_locales',
+            'name' => 'required|array|valid_language',
             'filterable' => 'boolean',
             'searchable' => 'boolean',
             'position' => 'integer',

--- a/src/Http/Requests/Products/UpdateRequest.php
+++ b/src/Http/Requests/Products/UpdateRequest.php
@@ -39,7 +39,7 @@ class UpdateRequest extends FormRequest
 
         foreach ($attributes as $attribute) {
             if ($attribute->required) {
-                $rulestring = 'attribute_data.'.$attribute->handle.'.'.$defaultChannel->handle.'.'.$defaultLanguage->lang;
+                $rulestring = 'attribute_data.'.$attribute->handle.'.'.$defaultChannel->handle.'.'.$defaultLanguage->code;
                 // $ruleset[$rulestring] = 'required';
             }
         }

--- a/src/Http/Requests/Tags/CreateRequest.php
+++ b/src/Http/Requests/Tags/CreateRequest.php
@@ -25,7 +25,7 @@ class CreateRequest extends FormRequest
     public function rules(Tag $tag)
     {
         return [
-            'name' => 'array|required|valid_locales',
+            'name' => 'array|required|valid_language',
         ];
     }
 }

--- a/src/Http/Requests/Tags/UpdateRequest.php
+++ b/src/Http/Requests/Tags/UpdateRequest.php
@@ -24,7 +24,7 @@ class UpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|array|valid_locales',
+            'name' => 'required|array|valid_language',
         ];
     }
 }

--- a/src/Http/Validators/LanguageValidator.php
+++ b/src/Http/Validators/LanguageValidator.php
@@ -4,7 +4,7 @@ namespace GetCandy\Api\Http\Validators;
 
 use GetCandy\Api\Core\Languages\Actions\FetchLanguages;
 
-class LocaleValidator
+class LanguageValidator
 {
     /**
      * Validates the name for an attribute doesn't exist in the same group.
@@ -20,15 +20,14 @@ class LocaleValidator
         if (! is_array($value)) {
             return false;
         }
-        $locales = array_keys($value);
+        $codes = array_keys($value);
 
         $languages = FetchLanguages::run([
             'paginate' => false,
             'search' => [
-                'lang' => $locales,
+                'code' => $codes,
             ],
         ]);
-
-        return $languages->count() === count($locales);
+        return $languages->count() === count($codes);
     }
 }

--- a/src/Http/Validators/LanguageValidator.php
+++ b/src/Http/Validators/LanguageValidator.php
@@ -28,6 +28,7 @@ class LanguageValidator
                 'code' => $codes,
             ],
         ]);
+
         return $languages->count() === count($codes);
     }
 }

--- a/src/Installer/Runners/LanguageRunner.php
+++ b/src/Installer/Runners/LanguageRunner.php
@@ -16,8 +16,7 @@ class LanguageRunner extends AbstractRunner implements InstallRunnerContract
     {
         $this->availableLanguages = collect([
             'gb' => [
-                'lang' => 'en',
-                'iso' => 'gb',
+                'code' => 'en',
                 'name' => 'English',
                 'default' => true,
             ],

--- a/src/Installer/Runners/UserRunner.php
+++ b/src/Installer/Runners/UserRunner.php
@@ -10,9 +10,7 @@ class UserRunner extends AbstractRunner implements InstallRunnerContract
 {
     public function run()
     {
-        if (! DB::table('roles')->count()) {
-            $this->installRoles();
-        }
+        $this->installRoles();
 
         $model = config('auth.providers.users.model');
 

--- a/src/Providers/ApiServiceProvider.php
+++ b/src/Providers/ApiServiceProvider.php
@@ -127,7 +127,7 @@ class ApiServiceProvider extends ServiceProvider
         Validator::extend('valid_structure', 'GetCandy\Api\Http\Validators\AttributeValidator@validateData');
         Validator::extend('unique_category_attribute', 'GetCandy\Api\Http\Validators\CategoriesValidator@uniqueCategoryAttributeData');
         Validator::extend('check_coupon', 'GetCandy\Api\Core\Discounts\Validators\DiscountValidator@checkCoupon');
-        Validator::extend('valid_locales', 'GetCandy\Api\Http\Validators\LocaleValidator@validate');
+        Validator::extend('valid_language', 'GetCandy\Api\Http\Validators\LanguageValidator@validate');
         Validator::extend('enabled', 'GetCandy\Api\Http\Validators\BaseValidator@enabled');
         Validator::extend('asset_url', 'GetCandy\Api\Http\Validators\AssetValidator@validAssetUrl');
         Validator::extend('valid_discount', 'GetCandy\Api\Core\Discounts\Validators\DiscountValidator@validate');

--- a/tests/Feature/Actions/Languages/CreateLanguageTest.php
+++ b/tests/Feature/Actions/Languages/CreateLanguageTest.php
@@ -34,6 +34,8 @@ class CreateLanguageTest extends FeatureCase
             '={}2ed]',
             '1234}',
             '1{@3{5}',
+            'semicolon;',
+            '1{@3{5}-',
         ];
 
         foreach ($codes as $code) {
@@ -56,9 +58,9 @@ class CreateLanguageTest extends FeatureCase
 
         $codes = [
             'DE-DE-12',
-            '=2dw3e-',
-            'DE GB',
-            '*DE =RF',
+            '2dw3e-2',
+            'DEGB',
+            '09-DE',
         ];
 
         foreach ($codes as $code) {

--- a/tests/Feature/Actions/Languages/CreateLanguageTest.php
+++ b/tests/Feature/Actions/Languages/CreateLanguageTest.php
@@ -14,8 +14,7 @@ class CreateLanguageTest extends FeatureCase
         $user = $this->admin();
 
         $response = $this->actingAs($user)->json('POST', 'languages', [
-            'lang' => 'en',
-            'iso' => 'gba',
+            'code' => 'gbr',
             'name' => 'English',
             'default' => 1,
             'enabled' => 1,
@@ -24,5 +23,55 @@ class CreateLanguageTest extends FeatureCase
         $response->assertStatus(201);
 
         $this->assertResponseValid($response, '/languages', 'post');
+    }
+
+    public function test_validation_works_on_code_field()
+    {
+        $user = $this->admin();
+
+        $codes = [
+            '{}tg12}',
+            '={}2ed]',
+            '1234}',
+            '1{@3{5}'
+        ];
+
+        foreach ($codes as $code) {
+            $response = $this->actingAs($user)->json('POST', 'languages', [
+                'code' => $code,
+                'name' => 'English',
+                'default' => 1,
+                'enabled' => 1,
+            ]);
+
+            $response->assertStatus(422);
+
+            $this->assertResponseValid($response, '/languages', 'post');
+        }
+    }
+
+    public function test_validation_allows_code_pattern()
+    {
+        $user = $this->admin();
+
+        $codes = [
+            'DE-DE-12',
+            '=2dw3e-',
+            'DE GB',
+            '*DE =RF'
+        ];
+
+        foreach ($codes as $code) {
+            $response = $this->actingAs($user)->json('POST', 'languages', [
+                'code' => $code,
+                'name' => 'English',
+                'default' => 1,
+                'enabled' => 1,
+            ]);
+
+            $response->assertStatus(201);
+
+            $this->assertResponseValid($response, '/languages', 'post');
+        }
     }
 }

--- a/tests/Feature/Actions/Languages/CreateLanguageTest.php
+++ b/tests/Feature/Actions/Languages/CreateLanguageTest.php
@@ -33,7 +33,7 @@ class CreateLanguageTest extends FeatureCase
             '{}tg12}',
             '={}2ed]',
             '1234}',
-            '1{@3{5}'
+            '1{@3{5}',
         ];
 
         foreach ($codes as $code) {
@@ -58,7 +58,7 @@ class CreateLanguageTest extends FeatureCase
             'DE-DE-12',
             '=2dw3e-',
             'DE GB',
-            '*DE =RF'
+            '*DE =RF',
         ];
 
         foreach ($codes as $code) {

--- a/tests/Feature/Http/Attributes/AttributeControllerTest.php
+++ b/tests/Feature/Http/Attributes/AttributeControllerTest.php
@@ -64,11 +64,6 @@ class AttributeControllerTest extends FeatureCase
         $this->assertResponseValid($response, '/attributes/{attributeId}');
     }
 
-    /**
-     * @group fail
-     *
-     * @return  [type]  [return description]
-     */
     public function test_can_update_an_attribute()
     {
         $user = $this->admin();

--- a/tests/Feature/Http/Attributes/AttributeControllerTest.php
+++ b/tests/Feature/Http/Attributes/AttributeControllerTest.php
@@ -64,6 +64,11 @@ class AttributeControllerTest extends FeatureCase
         $this->assertResponseValid($response, '/attributes/{attributeId}');
     }
 
+    /**
+     * @group fail
+     *
+     * @return  [type]  [return description]
+     */
     public function test_can_update_an_attribute()
     {
         $user = $this->admin();

--- a/tests/Unit/Installer/Runners/LanguageRunnerTest.php
+++ b/tests/Unit/Installer/Runners/LanguageRunnerTest.php
@@ -22,8 +22,7 @@ class LanguageRunnerTest extends TestCase
         $runner->run();
 
         $this->assertDatabaseHas('languages', [
-            'lang' => 'en',
-            'iso' => 'gb',
+            'code' => 'en',
             'name' => 'English',
             'default' => 1,
             'enabled' => 1,

--- a/tests/Unit/Languages/Actions/FetchEnabledLanguageByCodeTest.php
+++ b/tests/Unit/Languages/Actions/FetchEnabledLanguageByCodeTest.php
@@ -11,21 +11,21 @@ use Tests\TestCase;
  */
 class FetchEnabledLanguageByCodeTest extends TestCase
 {
-    public function test_can_attach_user_to_customer_record()
+    public function test_can_fetch_languages()
     {
         $user = $this->admin();
 
         $languageA = factory(Language::class)->create([
             'enabled' => false,
-            'iso' => 'gba',
+            'code' => 'gba',
         ]);
         $languageB = factory(Language::class)->create([
             'enabled' => true,
-            'iso' => 'sk',
+            'code' => 'sk',
         ]);
         $languageC = factory(Language::class)->create([
             'enabled' => false,
-            'iso' => 'dk',
+            'code' => 'dk',
         ]);
 
         $this->assertFalse($languageA->enabled);
@@ -33,13 +33,13 @@ class FetchEnabledLanguageByCodeTest extends TestCase
         $this->assertFalse($languageC->enabled);
 
         $language = FetchEnabledLanguageByCode::run([
-            'code' => $languageB->iso,
+            'code' => $languageB->code,
         ]);
 
         $this->assertEquals($languageB->id, $language->id);
 
         $language = FetchEnabledLanguageByCode::run([
-            'code' => $languageC->iso,
+            'code' => $languageC->code,
         ]);
 
         $this->assertNull($language);

--- a/tests/Unit/Languages/Actions/FetchLanguagesTest.php
+++ b/tests/Unit/Languages/Actions/FetchLanguagesTest.php
@@ -56,29 +56,25 @@ class FetchLangugesTest extends TestCase
         $user = $this->admin();
 
         $languageA = factory(Language::class)->create([
-            'lang' => 'en',
-            'iso' => 'gba',
+            'code' => 'gba',
             'enabled' => true,
         ]);
         $languageB = factory(Language::class)->create([
-            'lang' => 'sk',
-            'iso' => 'sk',
+            'code' => 'sk',
             'enabled' => true,
         ]);
         $languageC = factory(Language::class)->create([
-            'lang' => 'dk',
-            'iso' => 'dk',
+            'code' => 'dk',
             'enabled' => true,
         ]);
-
         $languages = FetchLanguages::run([
             'paginate' => false,
             'search' => [
-                'lang' => ['en', 'sk'],
+                'code' => ['en', 'sk'],
             ],
         ]);
 
-        $test = Language::whereIn('lang', ['en', 'sk'])->count();
+        $test = Language::whereIn('code', ['en', 'sk'])->count();
 
         $this->assertEquals($test, $languages->count());
     }


### PR DESCRIPTION


**Description**
This PR refactors languages.

- Removed `lang` and `iso` columns.
- Added `code` column (replaces `lang`)
- Adjusted middleware that sets the language to parse the `accept-language` header using a package instead of relying on a php extension being installed.
- Adjusted codebase to reflect the new `code` column
- Updated product indexer

**Checks**
- [x] Works with a fresh install
- [ ] Documentation updated
  - [x] Changelog
  - [x] Upgrade guide
  - [] Do these changes impact the hub and require a new version
