### PR TITLE
Basic idea to try detect if attribute data needs mapping or not (unte…

### DIFF
--- a/src/Core/Traits/HasAttributes.php
+++ b/src/Core/Traits/HasAttributes.php
@@ -75,7 +75,7 @@ trait HasAttributes
 
     public function setAttributeDataAttribute($val)
     {
-        if (! $this->id) {
+        if (! $this->requiresMapping($val)) {
             $this->attributes['attribute_data'] = json_encode($this->mapAttributes($val));
         } else {
             // dd(json_encode($val));
@@ -161,10 +161,8 @@ trait HasAttributes
         return $attributeData;
     }
 
-    // public function getAttributes()
-    // {
-    //     $attributes = $this->attributes;
-    //     $attributes['attribute_data'] = $this->getAttributeDataAttribute($attributes['attribute_data']);
-    //     return $attributes;
-    // }
+    protected function requiresMapping($data)
+    {
+        return ! is_array(array_shift(array_shift($data)));
+    }
 }


### PR DESCRIPTION
Untested, just an idea at present.

Want to allow creation and updating of the `attribute_data` Eloquent field using the same consistent format. Currently, creation routines use a different format, and the mapping function adds in the channels which are not provided.

The idea is we test the attribute data array to see how deep it is. If it is "shallow" then we assume it requires mapping, but if it's the correct depth (attribute > channel > language) then we assume the attribute data is already in the correct format. I guess we could go further if we wanted by checking for valid locales or similar.


