### PR TITLE
Add measurement values to mass assignment

### DIFF
--- a/src/Core/Products/Models/ProductVariant.php
+++ b/src/Core/Products/Models/ProductVariant.php
@@ -41,6 +41,16 @@ class ProductVariant extends BaseModel
         'max_qty',
         'min_batch',
         'tax_id',
+        'weight_value',
+        'weight_unit',
+        'height_value',
+        'height_unit',
+        'width_value',
+        'width_unit',
+        'depth_value',
+        'depth_unit',
+        'volume_value',
+        'volume_unit',
     ];
 
     protected $pricing;


### PR DESCRIPTION
Adds measurement values and units to be mass assignable on the `ProductVariant` model. Should fix an issue where these values weren't being persisted when publishing a draft.