### PR TITLE
Add product position when pivot is loaded.

### DIFF
--- a/src/Http/Resources/Products/ProductResource.php
+++ b/src/Http/Resources/Products/ProductResource.php
@@ -24,6 +24,7 @@ class ProductResource extends AbstractResource
             'id' => $this->encoded_id,
             'drafted_at' => $this->drafted_at,
             'option_data' => $this->parseOptionData($this->option_data),
+            'position' => $this->when(($this->pivot && $this->pivot->position), $this->pivot->position ?? 0),
             'variants_count' => $this->variants_count,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,


### PR DESCRIPTION
This PR adds the position to the product resource when the pivot exists.

This helps when reordering products attached to categories