### PR TITLE
Add basic validation on discounts

### DIFF
--- a/src/Http/Controllers/Discounts/DiscountController.php
+++ b/src/Http/Controllers/Discounts/DiscountController.php
@@ -33,6 +33,15 @@ class DiscountController extends BaseController
 
     public function update($id, UpdateRequest $request)
     {
+        $rules = [];
+
+        if (!empty($request->sets)) {
+            $rules['sets'] = 'array';
+            $rules['sets.*.items.*.value'] = 'required';
+        }
+
+        $this->validate($request, $rules);
+
         return new DiscountResource(
             GetCandy::discounts()->update($id, $request->all())
         );


### PR DESCRIPTION
This PR looks to add some simple validation to discounts when updating so things like coupons can't be empty.
