### PR TITLE
Hotfix - Remove other discount lines before re adding

### DIFF
--- a/src/Core/Orders/Factories/OrderFactory.php
+++ b/src/Core/Orders/Factories/OrderFactory.php
@@ -557,6 +557,12 @@ class OrderFactory implements OrderFactoryInterface
 
                                 $tax = $this->tax->amount($taxable);
 
+                                // Does this product already exist on the order
+                                $order->lines()
+                                    ->whereSku($variant->sku)
+                                    ->where('discount_total', '!=', 0)
+                                    ->delete();
+
                                 $order->lines()->create([
                                     'product_variant_id' => $variant->id,
                                     'sku' => $variant->sku,


### PR DESCRIPTION
There's an issue where discount lines are being duplicated on an order. This PR removes those to avoid conflict before re-adding them.